### PR TITLE
Intent-based availability, DB limits, connections rate limit

### DIFF
--- a/__tests__/lib/supabaseAuth.test.ts
+++ b/__tests__/lib/supabaseAuth.test.ts
@@ -5,12 +5,12 @@ import { getAuthenticatedSupabase } from '@/lib/server/supabaseAuth';
 /* ------------------------------------------------------------------ */
 
 const mockGetUser = jest.fn();
-const mockCreateClient = jest.fn(() => ({
+const mockCreateClient = jest.fn((_url?: string, _key?: string, _options?: object) => ({
   auth: { getUser: mockGetUser },
 }));
 
 jest.mock('@supabase/supabase-js', () => ({
-  createClient: (...args: unknown[]) => mockCreateClient(...args),
+  createClient: (url: string, key: string, options?: object) => mockCreateClient(url, key, options),
 }));
 
 function buildMockRequest(overrides: {

--- a/database/migrations/20260403180000_intent_availability_and_limits.sql
+++ b/database/migrations/20260403180000_intent_availability_and_limits.sql
@@ -1,0 +1,110 @@
+-- Intent-Based Availability + data integrity limits
+-- Idempotent where possible (IF NOT EXISTS / guarded DO blocks).
+
+-- ─── 1. availability_intents ───────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.availability_intents (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    timeframe varchar NOT NULL,
+    intent_tag varchar(25) NOT NULL,
+    expires_at timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_availability_intents_user_id
+    ON public.availability_intents (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_availability_intents_expires_at
+    ON public.availability_intents (expires_at);
+
+COMMENT ON TABLE public.availability_intents IS
+    'Short-lived user availability windows with an intent tag (e.g. coffee, walk).';
+
+ALTER TABLE public.availability_intents ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "availability_intents_own_all" ON public.availability_intents;
+CREATE POLICY "availability_intents_own_all"
+    ON public.availability_intents
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.availability_intents TO authenticated;
+
+-- ─── 2. messages: max body/content length (1000 chars) ────────────────────
+-- App schema uses `content`; constraint name references product term "body".
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'messages'
+          AND column_name = 'body'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'messages_body_max_length'
+        ) THEN
+            ALTER TABLE public.messages
+                ADD CONSTRAINT messages_body_max_length
+                CHECK (char_length(body) <= 1000);
+        END IF;
+    ELSIF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'messages'
+          AND column_name = 'content'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'messages_body_max_length'
+        ) THEN
+            ALTER TABLE public.messages
+                ADD CONSTRAINT messages_body_max_length
+                CHECK (char_length(content) <= 1000);
+        END IF;
+    END IF;
+END $$;
+
+-- ─── 3. profiles.interests: max 5 tags, each <= 25 chars ───────────────────
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'profiles'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'profiles'
+              AND column_name = 'interests'
+        ) THEN
+            ALTER TABLE public.profiles
+                ADD COLUMN interests text[] NOT NULL DEFAULT '{}'::text[];
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'profiles_interests_limits'
+        ) THEN
+            ALTER TABLE public.profiles
+                ADD CONSTRAINT profiles_interests_limits
+                CHECK (
+                    cardinality(interests) <= 5
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM unnest(interests) AS t (tag)
+                        WHERE char_length(tag) > 25
+                    )
+                );
+        END IF;
+    END IF;
+END $$;

--- a/database/migrations/20260403180000_intent_availability_and_limits.sql
+++ b/database/migrations/20260403180000_intent_availability_and_limits.sql
@@ -72,6 +72,22 @@ END $$;
 
 -- ─── 3. profiles.interests: max 5 tags, each <= 25 chars ───────────────────
 
+-- Helper: returns TRUE when every element in the array is <= max_len chars.
+-- IMMUTABLE so it can be referenced inside a CHECK constraint.
+CREATE OR REPLACE FUNCTION public.check_array_element_lengths(arr text[], max_len int)
+    RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    elem text;
+BEGIN
+    IF arr IS NULL THEN RETURN TRUE; END IF;
+    FOREACH elem IN ARRAY arr LOOP
+        IF char_length(elem) > max_len THEN RETURN FALSE; END IF;
+    END LOOP;
+    RETURN TRUE;
+END;
+$$;
+
 DO $$
 BEGIN
     IF EXISTS (
@@ -99,11 +115,7 @@ BEGIN
                 ADD CONSTRAINT profiles_interests_limits
                 CHECK (
                     cardinality(interests) <= 5
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM unnest(interests) AS t (tag)
-                        WHERE char_length(tag) > 25
-                    )
+                    AND public.check_array_element_lengths(interests, 25)
                 );
         END IF;
     END IF;

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,12 +2,65 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { userMayAccessBusinessInsights } from '@/lib/server/businessInsightsEligibility';
 
+const CONNECTIONS_RATE_LIMIT = 10;
+const CONNECTIONS_RATE_WINDOW_MS = 60_000;
+
+const connectionsRequestTimestampsByIp = new Map<string, number[]>();
+
+function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  if (realIp) return realIp;
+  return 'unknown';
+}
+
+function isConnectionsApiPath(pathname: string): boolean {
+  return pathname === '/api/connections' || pathname.startsWith('/api/connections/');
+}
+
+function connectionsRateLimitExceeded(ip: string): boolean {
+  const now = Date.now();
+  const windowStart = now - CONNECTIONS_RATE_WINDOW_MS;
+  let stamps = connectionsRequestTimestampsByIp.get(ip) ?? [];
+  stamps = stamps.filter((t) => t > windowStart);
+  if (stamps.length >= CONNECTIONS_RATE_LIMIT) {
+    connectionsRequestTimestampsByIp.set(ip, stamps);
+    return true;
+  }
+  stamps.push(now);
+  connectionsRequestTimestampsByIp.set(ip, stamps);
+  if (connectionsRequestTimestampsByIp.size > 50_000) {
+    for (const [key, ts] of connectionsRequestTimestampsByIp) {
+      const recent = ts.filter((t) => t > windowStart);
+      if (recent.length === 0) connectionsRequestTimestampsByIp.delete(key);
+      else connectionsRequestTimestampsByIp.set(key, recent);
+    }
+  }
+  return false;
+}
+
 export async function middleware(request: NextRequest) {
   let response = NextResponse.next({
     request: {
       headers: request.headers,
     },
   });
+
+  if (isConnectionsApiPath(request.nextUrl.pathname) && connectionsRateLimitExceeded(getClientIp(request))) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': '60',
+        },
+      },
+    );
+  }
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "lint": "tsc --noEmit",
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/supabase/functions/match-availability/index.ts
+++ b/supabase/functions/match-availability/index.ts
@@ -1,0 +1,223 @@
+/**
+ * Edge Function: match-availability
+ * Finds overlapping timeframe + intent_tag among peers on mutually kept connections
+ * and returns a push-notification-shaped payload (for send-push-notification or FCM).
+ *
+ * Invoke with Authorization: Bearer <user JWT>
+ *
+ * Timeframe format: "ISO_START/ISO_END" (UTC), e.g. 2026-04-03T14:00:00.000Z/2026-04-03T16:00:00.000Z
+ */
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+
+const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+function parseRange(timeframe: string): { start: number; end: number } | null {
+  const parts = timeframe.split('/');
+  if (parts.length !== 2) return null;
+  const start = Date.parse(parts[0].trim());
+  const end = Date.parse(parts[1].trim());
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+  return { start, end };
+}
+
+function rangesOverlap(a: { start: number; end: number }, b: { start: number; end: number }): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}
+
+function isMutuallyKept(row: {
+  should_continue?: boolean[] | null;
+  expiry_state?: string | null;
+}): boolean {
+  const sc = row.should_continue;
+  if (Array.isArray(sc) && sc.length >= 2 && sc[0] === true && sc[1] === true) {
+    return true;
+  }
+  return row.expiry_state === 'kept';
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const jwt = authHeader.replace(/^Bearer\s+/i, '').trim();
+  if (!jwt) {
+    return new Response(JSON.stringify({ error: 'Missing Authorization bearer token' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  if (!supabaseUrl || !serviceKey) {
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const admin = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  const { data: userData, error: userErr } = await admin.auth.getUser(jwt);
+  if (userErr || !userData?.user) {
+    return new Response(JSON.stringify({ error: 'Invalid or expired token' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const userId = userData.user.id;
+  const nowIso = new Date().toISOString();
+
+  const { data: connections, error: connErr } = await admin
+    .from('connections')
+    .select('id, user_ids, should_continue, expiry_state')
+    .contains('user_ids', [userId]);
+
+  if (connErr) {
+    return new Response(JSON.stringify({ error: connErr.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const peerIds = new Set<string>();
+  const connectionByPeer = new Map<string, string>();
+
+  for (const row of connections ?? []) {
+    if (!isMutuallyKept(row)) continue;
+    const ids = (row.user_ids as string[] | null) ?? [];
+    const peer = ids.find((id) => id !== userId);
+    if (!peer) continue;
+    peerIds.add(peer);
+    connectionByPeer.set(peer, row.id as string);
+  }
+
+  if (peerIds.size === 0) {
+    return new Response(
+      JSON.stringify({
+        matches: [],
+        push_notification: null,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const { data: myIntents, error: myErr } = await admin
+    .from('availability_intents')
+    .select('id, timeframe, intent_tag, expires_at')
+    .eq('user_id', userId)
+    .gt('expires_at', nowIso);
+
+  if (myErr) {
+    return new Response(JSON.stringify({ error: myErr.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const peerList = [...peerIds];
+  const { data: peerIntents, error: peerErr } = await admin
+    .from('availability_intents')
+    .select('id, user_id, timeframe, intent_tag, expires_at')
+    .in('user_id', peerList)
+    .gt('expires_at', nowIso);
+
+  if (peerErr) {
+    return new Response(JSON.stringify({ error: peerErr.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  type IntentRow = {
+    id: string;
+    user_id?: string;
+    timeframe: string;
+    intent_tag: string;
+    expires_at: string;
+  };
+
+  const matches: Array<{
+    intent_tag: string;
+    timeframe_a: string;
+    timeframe_b: string;
+    peer_user_id: string;
+    connection_id: string;
+    intent_ids: [string, string];
+  }> = [];
+
+  for (const mine of (myIntents ?? []) as IntentRow[]) {
+    const myRange = parseRange(mine.timeframe);
+    if (!myRange) continue;
+    const myTag = normalizeTag(mine.intent_tag);
+    if (!myTag) continue;
+
+    for (const theirs of (peerIntents ?? []) as IntentRow[]) {
+      if (!theirs.user_id || theirs.user_id === userId) continue;
+      if (normalizeTag(theirs.intent_tag) !== myTag) continue;
+      const theirRange = parseRange(theirs.timeframe);
+      if (!theirRange) continue;
+      if (!rangesOverlap(myRange, theirRange)) continue;
+
+      const connectionId = connectionByPeer.get(theirs.user_id);
+      if (!connectionId) continue;
+
+      matches.push({
+        intent_tag: mine.intent_tag.trim(),
+        timeframe_a: mine.timeframe,
+        timeframe_b: theirs.timeframe,
+        peer_user_id: theirs.user_id,
+        connection_id: connectionId,
+        intent_ids: [mine.id, theirs.id],
+      });
+    }
+  }
+
+  let push_notification: Record<string, unknown> | null = null;
+
+  if (matches.length > 0) {
+    const m = matches[0];
+    const peerLabel = m.peer_user_id.slice(0, 8);
+    push_notification = {
+      title: 'Availability match',
+      body: `You and a connection are both available for “${m.intent_tag}”.`,
+      data: {
+        type: 'availability_match',
+        intent_tag: m.intent_tag,
+        your_timeframe: m.timeframe_a,
+        peer_timeframe: m.timeframe_b,
+        peer_user_id: m.peer_user_id,
+        connection_id: m.connection_id,
+        match_count: String(matches.length),
+      },
+    };
+  }
+
+  return new Response(
+    JSON.stringify({
+      matches,
+      push_notification,
+    }),
+    { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+  );
+});

--- a/supabase/functions/match-availability/index.ts
+++ b/supabase/functions/match-availability/index.ts
@@ -197,7 +197,6 @@ Deno.serve(async (req) => {
 
   if (matches.length > 0) {
     const m = matches[0];
-    const peerLabel = m.peer_user_id.slice(0, 8);
     push_notification = {
       title: 'Availability match',
       body: `You and a connection are both available for “${m.intent_tag}”.`,

--- a/supabase/migrations/20260403180000_intent_availability_and_limits.sql
+++ b/supabase/migrations/20260403180000_intent_availability_and_limits.sql
@@ -1,0 +1,111 @@
+-- Intent-Based Availability + data integrity limits
+-- Idempotent where possible (IF NOT EXISTS / guarded DO blocks).
+-- Canonical copy: database/migrations/20260403180000_intent_availability_and_limits.sql
+
+-- ─── 1. availability_intents ───────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.availability_intents (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    timeframe varchar NOT NULL,
+    intent_tag varchar(25) NOT NULL,
+    expires_at timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_availability_intents_user_id
+    ON public.availability_intents (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_availability_intents_expires_at
+    ON public.availability_intents (expires_at);
+
+COMMENT ON TABLE public.availability_intents IS
+    'Short-lived user availability windows with an intent tag (e.g. coffee, walk).';
+
+ALTER TABLE public.availability_intents ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "availability_intents_own_all" ON public.availability_intents;
+CREATE POLICY "availability_intents_own_all"
+    ON public.availability_intents
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.availability_intents TO authenticated;
+
+-- ─── 2. messages: max body/content length (1000 chars) ────────────────────
+-- App schema uses `content`; constraint name references product term "body".
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'messages'
+          AND column_name = 'body'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'messages_body_max_length'
+        ) THEN
+            ALTER TABLE public.messages
+                ADD CONSTRAINT messages_body_max_length
+                CHECK (char_length(body) <= 1000);
+        END IF;
+    ELSIF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'messages'
+          AND column_name = 'content'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'messages_body_max_length'
+        ) THEN
+            ALTER TABLE public.messages
+                ADD CONSTRAINT messages_body_max_length
+                CHECK (char_length(content) <= 1000);
+        END IF;
+    END IF;
+END $$;
+
+-- ─── 3. profiles.interests: max 5 tags, each <= 25 chars ───────────────────
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'profiles'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'profiles'
+              AND column_name = 'interests'
+        ) THEN
+            ALTER TABLE public.profiles
+                ADD COLUMN interests text[] NOT NULL DEFAULT '{}'::text[];
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'profiles_interests_limits'
+        ) THEN
+            ALTER TABLE public.profiles
+                ADD CONSTRAINT profiles_interests_limits
+                CHECK (
+                    cardinality(interests) <= 5
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM unnest(interests) AS t (tag)
+                        WHERE char_length(tag) > 25
+                    )
+                );
+        END IF;
+    END IF;
+END $$;

--- a/supabase/migrations/20260403180000_intent_availability_and_limits.sql
+++ b/supabase/migrations/20260403180000_intent_availability_and_limits.sql
@@ -73,6 +73,22 @@ END $$;
 
 -- ─── 3. profiles.interests: max 5 tags, each <= 25 chars ───────────────────
 
+-- Helper: returns TRUE when every element in the array is <= max_len chars.
+-- IMMUTABLE so it can be referenced inside a CHECK constraint.
+CREATE OR REPLACE FUNCTION public.check_array_element_lengths(arr text[], max_len int)
+    RETURNS boolean
+    LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    elem text;
+BEGIN
+    IF arr IS NULL THEN RETURN TRUE; END IF;
+    FOREACH elem IN ARRAY arr LOOP
+        IF char_length(elem) > max_len THEN RETURN FALSE; END IF;
+    END LOOP;
+    RETURN TRUE;
+END;
+$$;
+
 DO $$
 BEGIN
     IF EXISTS (
@@ -100,11 +116,7 @@ BEGIN
                 ADD CONSTRAINT profiles_interests_limits
                 CHECK (
                     cardinality(interests) <= 5
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM unnest(interests) AS t (tag)
-                        WHERE char_length(tag) > 25
-                    )
+                    AND public.check_array_element_lengths(interests, 25)
                 );
         END IF;
     END IF;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds database support for **intent-based availability**, optional integrity checks on **messages** and **profiles**, a **Supabase Edge Function** to find overlapping availability among mutually kept connections, and a **sliding-window rate limit** on `/api/connections`.

## Database

- New table `public.availability_intents` (`id`, `user_id` → `auth.users`, `timeframe`, `intent_tag` varchar(25), `expires_at`) with RLS so users only manage their own rows.
- `messages`: adds `messages_body_max_length` on `body` **or** `content` (whichever exists), `char_length(...) <= 1000`.
- `profiles`: if the table exists, ensures `interests text[]` and adds `profiles_interests_limits` — max 5 elements, each `char_length <= 25`.

Migrations live in `database/migrations/20260403180000_intent_availability_and_limits.sql` and are duplicated under `supabase/migrations/` for Supabase CLI.

## Edge Function

- `supabase/functions/match-availability/index.ts` — validates Bearer JWT, finds peers on **mutually kept** connections (`should_continue = [true,true]` or `expiry_state = 'kept'`), matches overlapping `timeframe` (ISO start/end split by `/`) and case-insensitive `intent_tag`, returns `matches` and a `push_notification` payload.

## Next.js

- **Middleware**: 10 requests/minute per client IP for `/api/connections` and nested paths; **429** + `Retry-After: 60`.
- **Tooling**: `npm run lint` → `tsc --noEmit`; `tsconfig.json` excludes `supabase/functions` so Deno edge code does not break `next build`. Small fix to `supabaseAuth` test mock for strict TypeScript.

## Verification

- `npm run lint`
- `npm run build`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b95fbe60-c4d1-499b-b935-5639bd4724e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b95fbe60-c4d1-499b-b935-5639bd4724e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lightningbolts/click-web/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
