### PR TITLE
Dashboard: server lifecycle archives, profile intents, shared interests

### DIFF
--- a/__tests__/lib/userProfile/sharedInterests.test.ts
+++ b/__tests__/lib/userProfile/sharedInterests.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@jest/globals';
+import { getSharedInterestTags } from '@/lib/userProfile/sharedInterests';
+
+describe('getSharedInterestTags', () => {
+  it('returns intersection case-insensitively with viewer casing preserved', () => {
+    expect(
+      getSharedInterestTags(['Coffee', 'Hiking'], ['hiking', 'music']),
+    ).toEqual(['Hiking']);
+  });
+
+  it('returns empty when either side is empty', () => {
+    expect(getSharedInterestTags([], ['a'])).toEqual([]);
+    expect(getSharedInterestTags(['a'], [])).toEqual([]);
+  });
+
+  it('dedupes viewer duplicates', () => {
+    expect(getSharedInterestTags(['Run', 'run'], ['Run'])).toEqual(['Run']);
+  });
+});

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -3,6 +3,7 @@ import { createServerClient } from '@supabase/ssr';
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import type { ConnectionLifecycleStatus } from '@/types/connection';
+import { ACTIVE_CONNECTIONS_DB_OR_FILTER } from '@/lib/dashboard/connectionStatus';
 
 /**
  * Connections API
@@ -269,6 +270,8 @@ async function enrichMemoryCapsuleWeather(
 // ─── GET — fetch user's connections ──────────────────────────────────────────
 
 const INSIGHTS_QUERY_PARAM = 'includeInsights';
+/** `active` (default) | `archived` — ignored when `includeInsights` is set */
+const STATUS_SCOPE_PARAM = 'statusScope';
 
 function isInsightsScope(searchParams: URLSearchParams): boolean {
   const v = searchParams.get(INSIGHTS_QUERY_PARAM);
@@ -284,10 +287,11 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const insights = isInsightsScope(request.nextUrl.searchParams);
+    const searchParams = request.nextUrl.searchParams;
+    const insights = isInsightsScope(searchParams);
 
     // Active dashboard/chat views omit auto-archived and user-removed rows.
-    // Business Insights callers pass `?includeInsights=1` to include every lifecycle state.
+    // Archived tab: `?statusScope=archived`. Insights: `?includeInsights=1` for every lifecycle state.
     let query = supabase
       .from('connections')
       .select('*')
@@ -295,8 +299,12 @@ export async function GET(request: NextRequest) {
       .order('created', { ascending: false });
 
     if (!insights) {
-      // Omit server-side archived/removed; legacy null `status` stays visible.
-      query = query.or('status.is.null,status.eq.pending,status.eq.active,status.eq.kept');
+      const scope = searchParams.get(STATUS_SCOPE_PARAM)?.toLowerCase();
+      if (scope === 'archived') {
+        query = query.eq('status', 'archived');
+      } else {
+        query = query.or(ACTIVE_CONNECTIONS_DB_OR_FILTER);
+      }
     }
 
     const { data: connections, error } = await query;
@@ -309,6 +317,83 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ connections: connections || [] });
   } catch (error) {
     console.error('Server error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// ─── PATCH — restore server-archived connection back to active ───────────────
+
+type PatchBody = {
+  action?: string;
+  connectionId?: string;
+  id?: string;
+};
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const supabase = await createSupabaseSSRClient();
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: PatchBody;
+    try {
+      body = (await request.json()) as PatchBody;
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (body.action !== 'restore') {
+      return NextResponse.json({ error: 'Unsupported action' }, { status: 400 });
+    }
+
+    const connectionId = (body.connectionId ?? body.id)?.trim();
+    if (!connectionId) {
+      return NextResponse.json({ error: 'connectionId is required' }, { status: 400 });
+    }
+
+    const adminClient = createAdminClient();
+
+    const { data: row, error: fetchError } = await adminClient
+      .from('connections')
+      .select('id, user_ids, status')
+      .eq('id', connectionId)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error('Connection restore lookup error:', fetchError);
+      return NextResponse.json({ error: fetchError.message }, { status: 400 });
+    }
+
+    const ids = (row?.user_ids as string[] | null) ?? [];
+    if (!row || !ids.includes(user.id)) {
+      return NextResponse.json({ error: 'Connection not found' }, { status: 404 });
+    }
+
+    if (row.status !== 'archived') {
+      return NextResponse.json(
+        { error: 'Only archived connections can be restored' },
+        { status: 409 },
+      );
+    }
+
+    const activeStatus: ConnectionLifecycleStatus = 'active';
+    const { data: updated, error: updateError } = await adminClient
+      .from('connections')
+      .update({ status: activeStatus })
+      .eq('id', connectionId)
+      .select()
+      .maybeSingle();
+
+    if (updateError) {
+      console.error('Connection restore error:', updateError);
+      return NextResponse.json({ error: updateError.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, connection: updated });
+  } catch (error) {
+    console.error('Connection PATCH error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/users/[userId]/profile/route.ts
+++ b/app/api/users/[userId]/profile/route.ts
@@ -3,8 +3,26 @@
  * Returns joined profile for a user (respects RLS — typically connections only).
  */
 
+import { createClient } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedSupabase } from '@/lib/server/supabaseAuth';
+import { getSharedInterestTags } from '@/lib/userProfile/sharedInterests';
+
+function createAdminClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+export type AvailabilityIntentPayload = {
+  id: string;
+  timeframe: string;
+  intent_tag: string;
+  expires_at: string;
+};
 
 export async function GET(
   req: NextRequest,
@@ -28,6 +46,39 @@ export async function GET(
       supabase.from('user_interests').select('tags').eq('user_id', userId).maybeSingle(),
       supabase.from('user_availability').select('*').eq('user_id', userId).maybeSingle(),
     ]);
+
+    const profileTags = (interestsRes.data as { tags?: string[] } | null)?.tags ?? [];
+
+    let availabilityIntents: AvailabilityIntentPayload[] = [];
+    try {
+      const admin = createAdminClient();
+      const { data: intentRows, error: intentErr } = await admin
+        .from('availability_intents')
+        .select('id, timeframe, intent_tag, expires_at')
+        .eq('user_id', userId)
+        .gt('expires_at', new Date().toISOString())
+        .order('expires_at', { ascending: true });
+
+      if (!intentErr && intentRows) {
+        availabilityIntents = intentRows as AvailabilityIntentPayload[];
+      } else if (intentErr) {
+        console.warn('profile availability_intents:', intentErr.message);
+      }
+    } catch (e) {
+      console.warn('profile availability_intents fetch failed:', e);
+    }
+
+    let viewerInterestTags: string[] = [];
+    let sharedInterestTags: string[] = [];
+    if (user.id !== userId) {
+      const { data: myRow } = await supabase
+        .from('user_interests')
+        .select('tags')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      viewerInterestTags = (myRow as { tags?: string[] } | null)?.tags ?? [];
+      sharedInterestTags = getSharedInterestTags(viewerInterestTags, profileTags);
+    }
 
     if (userRes.error) {
       return NextResponse.json({ error: userRes.error.message }, { status: 500 });
@@ -59,8 +110,11 @@ export async function GET(
 
     return NextResponse.json({
       user: userRes.data,
-      tags: (interestsRes.data as { tags?: string[] } | null)?.tags ?? [],
+      tags: profileTags,
       availability: availRes.data ?? null,
+      availabilityIntents,
+      viewerInterestTags,
+      sharedInterestTags,
       sharedConnection,
     });
   } catch (e: unknown) {

--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -1282,17 +1282,19 @@ export default function DashboardView({ user }: DashboardViewProps) {
           (typeof otherUserName === 'string' && otherUserName.trim()) ||
           'Connection';
 
+        const rawDateValue = conn.created_utc || conn.created || conn.created_at || 0;
         const createdMs =
           typeof conn.created === 'number' && Number.isFinite(conn.created)
             ? conn.created
-            : new Date(String(conn.created_utc || conn.created_at || 0)).getTime();
+            : new Date(typeof rawDateValue === 'number' ? rawDateValue : String(rawDateValue)).getTime();
 
+        const dateMetValue = conn.created_utc || conn.created || conn.created_at;
         return {
           id: String(conn.id),
           otherUserId,
           userIds,
           name: displayName,
-          dateMet: new Date(String(conn.created_utc || conn.created || conn.created_at)),
+          dateMet: new Date(typeof dateMetValue === 'number' ? dateMetValue : String(dateMetValue ?? 0)),
           location:
             (typeof conn.semantic_location === 'string' && conn.semantic_location) || 'Unknown location',
           context: extractEventContext(conn),

--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -88,6 +88,7 @@ import {
   normalizeNoiseCategory,
 } from '@/lib/dashboard/connectionExtras';
 import {
+  ACTIVE_CONNECTIONS_DB_OR_FILTER,
   connectionRecordToArchiveRow,
   formatArchiveCountdownLabel,
   getArchiveCountdown,
@@ -988,7 +989,10 @@ export default function DashboardView({ user }: DashboardViewProps) {
 
     const loadChatMetadata = async () => {
       const connectionIds = connectionRecords
-        .filter((connection) => isActiveChatListStatus(connection.status))
+        .filter(
+          (connection) =>
+            isActiveChatListStatus(connection.status) || connection.status === 'archived',
+        )
         .map((connection) => connection.id);
 
       if (connectionIds.length === 0) {
@@ -1151,135 +1155,168 @@ export default function DashboardView({ user }: DashboardViewProps) {
     };
 
     try {
-      const { data, error } = await supabase
+      const activeQuery = supabase
         .from('connections')
         .select('*')
         .contains('user_ids', [user.id])
+        .or(ACTIVE_CONNECTIONS_DB_OR_FILTER)
         .order('created', { ascending: false });
 
-      if (error) {
-        console.error('Error fetching connections:', error.message || error);
-        setEmptyConnections();
-      } else if (data && data.length > 0) {
-        // Resolve other user names from the users table
-        const otherUserIds = data.flatMap((conn: any) =>
-          (conn.user_ids || []).filter((id: string) => id !== user.id)
-        ).filter((id: string, i: number, arr: string[]) => arr.indexOf(id) === i);
+      const archivedQuery = supabase
+        .from('connections')
+        .select('*')
+        .contains('user_ids', [user.id])
+        .eq('status', 'archived')
+        .order('created', { ascending: false });
 
-        let userNameMap: Record<string, string> = {};
-        if (otherUserIds.length > 0) {
-          // Resolve names through the server so we can fall back to auth metadata
-          // when profile rows are incomplete.
-          try {
-            const nameRes = await fetch('/api/users/display-names', {
-              method: 'POST',
-              headers: await getAuthHeaders(),
-              body: JSON.stringify({ userIds: otherUserIds }),
-            });
-            if (nameRes.ok) {
-              const payload = await nameRes.json();
-              userNameMap = payload?.names ?? {};
-            }
-          } catch {
-            // Fall through to direct DB lookup below.
+      const [activeRes, archivedRes] = await Promise.all([activeQuery, archivedQuery]);
+
+      if (activeRes.error) {
+        console.error('Error fetching connections:', activeRes.error.message || activeRes.error);
+        setEmptyConnections();
+        return;
+      }
+
+      if (archivedRes.error) {
+        console.warn('Archived connections fetch skipped:', archivedRes.error.message || archivedRes.error);
+      }
+
+      const mergedById = new Map<string, Record<string, unknown>>();
+      for (const row of (activeRes.data ?? []) as Record<string, unknown>[]) {
+        const id = row.id;
+        if (typeof id === 'string') mergedById.set(id, row);
+      }
+      for (const row of (archivedRes.data ?? []) as Record<string, unknown>[]) {
+        const id = row.id;
+        if (typeof id === 'string' && !mergedById.has(id)) mergedById.set(id, row);
+      }
+
+      const merged = Array.from(mergedById.values());
+      if (merged.length === 0) {
+        setEmptyConnections();
+        return;
+      }
+
+      const otherUserIds = merged
+        .flatMap((conn) => {
+          const ids = conn.user_ids;
+          if (!Array.isArray(ids)) return [] as string[];
+          return ids.filter((x): x is string => typeof x === 'string' && x !== user.id);
+        })
+        .filter((id, i, arr) => arr.indexOf(id) === i);
+
+      let userNameMap: Record<string, string> = {};
+      if (otherUserIds.length > 0) {
+        try {
+          const nameRes = await fetch('/api/users/display-names', {
+            method: 'POST',
+            headers: await getAuthHeaders(),
+            body: JSON.stringify({ userIds: otherUserIds }),
+          });
+          if (nameRes.ok) {
+            const payload = await nameRes.json();
+            userNameMap = payload?.names ?? {};
+          }
+        } catch {
+          // Fall through to direct DB lookup below.
+        }
+
+        if (Object.keys(userNameMap).length === 0) {
+          let usersData: any[] | null = null;
+          const { data: d1, error: e1 } = await supabase
+            .from('users')
+            .select('id, name, full_name, first_name, last_name, email')
+            .in('id', otherUserIds);
+          if (!e1 && d1) {
+            usersData = d1;
+          } else {
+            const { data: d2 } = await supabase
+              .from('users')
+              .select('id, name, email')
+              .in('id', otherUserIds);
+            usersData = d2;
           }
 
-          if (Object.keys(userNameMap).length === 0) {
-            // Fallback path if the server helper is unavailable.
-            let usersData: any[] | null = null;
-            const { data: d1, error: e1 } = await supabase
-              .from('users')
-              .select('id, name, full_name, first_name, last_name, email')
-              .in('id', otherUserIds);
-            if (!e1 && d1) {
-              usersData = d1;
-            } else {
-              const { data: d2 } = await supabase
-                .from('users')
-                .select('id, name, email')
-                .in('id', otherUserIds);
-              usersData = d2;
-            }
+          if (usersData) {
+            userNameMap = Object.fromEntries(
+              usersData.map((u: any) => {
+                const fromParts = [u.first_name, u.last_name]
+                  .filter((x: unknown) => typeof x === 'string' && (x as string).trim())
+                  .join(' ')
+                  .trim();
+                const resolvedName =
+                  fromParts ||
+                  (typeof u.full_name === 'string' && u.full_name.trim()) ||
+                  (typeof u.name === 'string' && u.name.trim()) ||
+                  (typeof u.email === 'string' && u.email.includes('@') ? u.email.split('@')[0] : '') ||
+                  '';
+                return [u.id, resolvedName];
+              })
+            );
+          }
+        }
+      }
 
-            if (usersData) {
-              userNameMap = Object.fromEntries(
-                usersData.map((u: any) => {
-                  const fromParts = [u.first_name, u.last_name]
-                    .filter((x: unknown) => typeof x === 'string' && (x as string).trim())
-                    .join(' ')
-                    .trim();
-                  const resolvedName =
-                    fromParts ||
-                    (typeof u.full_name === 'string' && u.full_name.trim()) ||
-                    (typeof u.name === 'string' && u.name.trim()) ||
-                    (typeof u.email === 'string' && u.email.includes('@') ? u.email.split('@')[0] : '') ||
-                    '';
-                  return [u.id, resolvedName];
-                })
-              );
-            }
+      const mapRowToRecord = (conn: Record<string, unknown>): ConnectionRecord => {
+        const userIds = (conn.user_ids as string[] | undefined) ?? [];
+        const otherUserId = userIds.find((id) => id !== user.id);
+        const otherUserName = (otherUserId && userNameMap[otherUserId]) || null;
+
+        let geoLoc: { latitude: number; longitude: number } | undefined;
+        const geo = conn.geo_location as Record<string, unknown> | null | undefined;
+        if (geo && typeof geo === 'object') {
+          const rawLat = geo.lat ?? geo.latitude;
+          const rawLon = geo.lon ?? geo.longitude ?? geo.lng ?? geo.long;
+          const lat = typeof rawLat === 'number' ? rawLat : Number(rawLat);
+          const lon = typeof rawLon === 'number' ? rawLon : Number(rawLon);
+          if (
+            typeof lat === 'number' && typeof lon === 'number' &&
+            isFinite(lat) && isFinite(lon) &&
+            !(lat === 0 && lon === 0)
+          ) {
+            geoLoc = { latitude: lat, longitude: lon };
           }
         }
 
-        const records: ConnectionRecord[] = data.map((conn: any) => {
-          // Resolve the other user's name
-          const otherUserId = (conn.user_ids || []).find((id: string) => id !== user.id);
-          const otherUserName = (otherUserId && userNameMap[otherUserId]) || null;
+        const displayName =
+          (typeof otherUserName === 'string' && otherUserName.trim()) ||
+          'Connection';
 
-          // Parse geo_location — DB stores { lat, lon }, filter out invalid coords
-          let geoLoc: { latitude: number; longitude: number } | undefined;
-          if (conn.geo_location) {
-            const rawLat = conn.geo_location.lat ?? conn.geo_location.latitude;
-            const rawLon = conn.geo_location.lon ?? conn.geo_location.longitude ?? conn.geo_location.lng ?? conn.geo_location.long;
-            const lat = typeof rawLat === 'number' ? rawLat : Number(rawLat);
-            const lon = typeof rawLon === 'number' ? rawLon : Number(rawLon);
-            if (
-              typeof lat === 'number' && typeof lon === 'number' &&
-              isFinite(lat) && isFinite(lon) &&
-              !(lat === 0 && lon === 0)
-            ) {
-              geoLoc = { latitude: lat, longitude: lon };
-            }
-          }
+        const createdMs =
+          typeof conn.created === 'number' && Number.isFinite(conn.created)
+            ? conn.created
+            : new Date(String(conn.created_utc || conn.created_at || 0)).getTime();
 
-          const displayName =
-            (typeof otherUserName === 'string' && otherUserName.trim()) ||
-            'Connection';
+        return {
+          id: String(conn.id),
+          otherUserId,
+          userIds,
+          name: displayName,
+          dateMet: new Date(String(conn.created_utc || conn.created || conn.created_at)),
+          location:
+            (typeof conn.semantic_location === 'string' && conn.semantic_location) || 'Unknown location',
+          context: extractEventContext(conn),
+          weatherSummary: extractWeatherSummary(conn),
+          noiseSummary: extractNoiseSummary(conn),
+          noiseCategory: normalizeNoiseCategory(conn),
+          status: normalizeConnectionStatus(conn),
+          lastMessageAt:
+            typeof conn.last_message_at === 'number' && Number.isFinite(conn.last_message_at)
+              ? conn.last_message_at
+              : null,
+          connectionCreatedMs: Number.isFinite(createdMs) ? createdMs : undefined,
+          hasBegun: conn.has_begun === true,
+          expiryState: typeof conn.expiry_state === 'string' ? conn.expiry_state : null,
+          geo_location: geoLoc,
+        };
+      };
 
-          const raw = conn as Record<string, unknown>;
-          const createdMs =
-            typeof conn.created === 'number' && Number.isFinite(conn.created)
-              ? conn.created
-              : new Date(conn.created_utc || conn.created_at || 0).getTime();
+      const records: ConnectionRecord[] = merged
+        .map(mapRowToRecord)
+        .sort((a, b) => b.dateMet.getTime() - a.dateMet.getTime());
 
-          return {
-            id: conn.id,
-            otherUserId,
-            userIds: conn.user_ids || [],
-            name: displayName,
-            dateMet: new Date(conn.created_utc || conn.created || conn.created_at),
-            location: conn.semantic_location || 'Unknown location',
-            context: extractEventContext(raw),
-            weatherSummary: extractWeatherSummary(raw),
-            noiseSummary: extractNoiseSummary(raw),
-            noiseCategory: normalizeNoiseCategory(raw),
-            status: normalizeConnectionStatus(raw),
-            lastMessageAt:
-              typeof conn.last_message_at === 'number' && Number.isFinite(conn.last_message_at)
-                ? conn.last_message_at
-                : null,
-            connectionCreatedMs: Number.isFinite(createdMs) ? createdMs : undefined,
-            hasBegun: conn.has_begun === true,
-            expiryState: typeof conn.expiry_state === 'string' ? conn.expiry_state : null,
-            geo_location: geoLoc,
-          };
-        });
-
-        setConnectionRecords(records);
-        setChapters(generateChaptersFromConnections(records));
-      } else {
-        setEmptyConnections();
-      }
+      setConnectionRecords(records);
+      setChapters(generateChaptersFromConnections(records));
     } catch (err) {
       console.error('Unexpected error fetching connections:', err);
       setEmptyConnections();
@@ -1538,38 +1575,73 @@ export default function DashboardView({ user }: DashboardViewProps) {
     }
   }, [archiveTableAvailable, isMissingArchiveTableError, updateArchivedIds, user?.id]);
 
-  const unarchiveConnection = useCallback(async (connectionId: string): Promise<boolean> => {
-    updateArchivedIds((prev) => {
-      const next = new Set(prev);
-      next.delete(connectionId);
-      return next;
-    });
-    setMenuConnectionId(null);
-    setChatListTab('active');
+  const unarchiveConnection = useCallback(
+    async (connectionId: string, rowStatus?: ConnectionRecord['status']): Promise<boolean> => {
+      updateArchivedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
+      setMenuConnectionId(null);
+      setChatListTab('active');
 
-    const supabase = getSupabaseClient();
-    if (!supabase || !user?.id || !archiveTableAvailable) return true;
-    try {
-      const { error } = await supabase
-        .from('connection_archives')
-        .delete()
-        .eq('user_id', user.id)
-        .eq('connection_id', connectionId);
+      const fromRecord = connectionRecords.find((c) => c.id === connectionId);
+      const effectiveStatus = rowStatus ?? fromRecord?.status;
 
-      if (error) {
-        if (isMissingArchiveTableError(error)) {
-          setArchiveTableAvailable(false);
+      if (effectiveStatus === 'archived') {
+        try {
+          const headers = await getAuthHeaders();
+          const res = await fetch('/api/connections', {
+            method: 'PATCH',
+            headers: { ...headers, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'restore', connectionId }),
+          });
+          if (!res.ok) {
+            const payload = await res.json().catch(() => ({}));
+            console.error('Server restore failed:', payload.error || res.statusText);
+            return false;
+          }
+          void loadConnections();
           return true;
+        } catch (e) {
+          console.error('Unexpected server restore error:', e);
+          return false;
         }
-        console.error('Error unarchiving connection:', error.message || error);
+      }
+
+      const supabase = getSupabaseClient();
+      if (!supabase || !user?.id || !archiveTableAvailable) return true;
+      try {
+        const { error } = await supabase
+          .from('connection_archives')
+          .delete()
+          .eq('user_id', user.id)
+          .eq('connection_id', connectionId);
+
+        if (error) {
+          if (isMissingArchiveTableError(error)) {
+            setArchiveTableAvailable(false);
+            return true;
+          }
+          console.error('Error unarchiving connection:', error.message || error);
+          return false;
+        }
+        return true;
+      } catch (err) {
+        console.error('Unexpected unarchive error:', err);
         return false;
       }
-      return true;
-    } catch (err) {
-      console.error('Unexpected unarchive error:', err);
-      return false;
-    }
-  }, [archiveTableAvailable, isMissingArchiveTableError, updateArchivedIds, user?.id]);
+    },
+    [
+      archiveTableAvailable,
+      connectionRecords,
+      getAuthHeaders,
+      isMissingArchiveTableError,
+      loadConnections,
+      updateArchivedIds,
+      user?.id,
+    ],
+  );
 
   const openActionMenu = useCallback((connectionId: string) => {
     setMenuConnectionId((prev) => (prev === connectionId ? null : connectionId));
@@ -1704,7 +1776,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
 
   const chatCandidates = useMemo(
     () => connectionRecords
-      .filter((c) => isActiveChatListStatus(c.status))
+      .filter((c) => isActiveChatListStatus(c.status) || c.status === 'archived')
       .map((connection) => {
         const metadata = chatMetadataByConnectionId[connection.id];
         return {
@@ -1723,14 +1795,28 @@ export default function DashboardView({ user }: DashboardViewProps) {
   );
 
   const activeConnections = useMemo(
-    () => chatCandidates.filter((c) => !archivedConnectionIds.has(c.id)),
-    [chatCandidates, archivedConnectionIds]
+    () =>
+      chatCandidates.filter(
+        (c) => !archivedConnectionIds.has(c.id) && c.status !== 'archived',
+      ),
+    [archivedConnectionIds, chatCandidates],
   );
 
-  const archivedConnections = useMemo(
-    () => chatCandidates.filter((c) => archivedConnectionIds.has(c.id)),
-    [chatCandidates, archivedConnectionIds]
-  );
+  const archivedConnections = useMemo(() => {
+    const serverArchived = chatCandidates.filter((c) => c.status === 'archived');
+    const userArchivedOnly = chatCandidates.filter(
+      (c) => archivedConnectionIds.has(c.id) && c.status !== 'archived',
+    );
+    const byId = new Map<string, (typeof chatCandidates)[number]>();
+    for (const c of [...serverArchived, ...userArchivedOnly]) {
+      if (!byId.has(c.id)) byId.set(c.id, c);
+    }
+    return Array.from(byId.values()).sort((a, b) => {
+      const left = a.chatLastMessageAt ?? a.chatUpdatedAt ?? a.dateMet.getTime();
+      const right = b.chatLastMessageAt ?? b.chatUpdatedAt ?? b.dateMet.getTime();
+      return right - left;
+    });
+  }, [archivedConnectionIds, chatCandidates]);
 
   const dashboardMetrics = useMemo(
     () => buildDashboardMetrics(connectionRecords),
@@ -1979,10 +2065,15 @@ export default function DashboardView({ user }: DashboardViewProps) {
                         connection={selectedConnection}
                         currentUserId={user.id}
                         otherUserName={selectedConnection.name}
-                        isArchived={archivedConnectionIds.has(selectedConnection.id)}
+                        isArchived={
+                          archivedConnectionIds.has(selectedConnection.id) ||
+                          selectedConnection.status === 'archived'
+                        }
                         isBlocked={selectedConnection.otherUserId ? blockedUserIds.has(selectedConnection.otherUserId) : false}
                         onArchive={() => archiveConnection(selectedConnection.id)}
-                        onUnarchive={() => unarchiveConnection(selectedConnection.id)}
+                        onUnarchive={() =>
+                          unarchiveConnection(selectedConnection.id, selectedConnection.status)
+                        }
                         onRemove={() => removeConnection(selectedConnection.id)}
                         onReport={(reason) => reportConnection(selectedConnection.id, reason)}
                         onBlock={() => blockUser(selectedConnection)}
@@ -2077,13 +2168,15 @@ export default function DashboardView({ user }: DashboardViewProps) {
                             <p className="text-zinc-400">
                               {chatListTab === 'active'
                                 ? 'Start meeting people and your chats will appear here!'
-                                : 'Archived chats will appear here.'}
+                                : 'Auto-archived chats and conversations you hid appear here. Tap Restore to move them back to Active.'}
                             </p>
                           </div>
                         ) : (
                           <div className="glass overflow-visible rounded-3xl border border-zinc-800 divide-y divide-zinc-800/50">
                             {visibleChatConnections.map((conn, index) => {
-                              const isArchived = archivedConnectionIds.has(conn.id);
+                              const isUserArchived = archivedConnectionIds.has(conn.id);
+                              const isServerArchived = conn.status === 'archived';
+                              const isArchived = isUserArchived || isServerArchived;
                               const previewText = conn.chatPreview?.trim() || 'No messages yet';
                               const activityLabel = formatChatActivity(conn.chatLastMessageAt ?? conn.chatUpdatedAt);
                               const archiveRow = connectionRecordToArchiveRow(conn);
@@ -2153,7 +2246,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
                                       <p className="mt-1 truncate pr-2 text-xs text-zinc-400">
                                         {conn.location} · {conn.dateMet.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                                       </p>
-                                      {archiveWarning && !isArchived ? (
+                                      {archiveWarning && !isServerArchived && !isUserArchived ? (
                                         <p
                                           className={`mt-1.5 flex items-center gap-1 truncate pr-2 text-[11px] ${
                                             archiveInfo?.isUrgent ? 'text-amber-300' : 'text-zinc-500'
@@ -2174,7 +2267,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
                                         <div className="flex flex-wrap items-center justify-end gap-2">
                                           {isArchived ? (
                                             <span className="shrink-0 rounded-full border border-zinc-600/40 bg-zinc-700/30 px-2 py-0.5 text-[10px] text-zinc-300">
-                                              Archived
+                                              {isServerArchived ? 'Auto-archived' : 'Archived'}
                                             </span>
                                           ) : null}
                                         </div>
@@ -2212,10 +2305,12 @@ export default function DashboardView({ user }: DashboardViewProps) {
                                       </button>
                                       {isArchived ? (
                                         <button
-                                          onClick={() => unarchiveConnection(conn.id)}
+                                          onClick={() =>
+                                            unarchiveConnection(conn.id, conn.status)
+                                          }
                                           className="w-full text-left px-3 py-2 text-sm text-[#7cc3ff] hover:bg-zinc-800"
                                         >
-                                          Unarchive
+                                          {isServerArchived ? 'Restore' : 'Unarchive'}
                                         </button>
                                       ) : (
                                         <button

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -8,6 +8,13 @@ import {
   type SharedConnectionPayload,
 } from '@/lib/userProfile/formatSharedConnection';
 
+export type AvailabilityIntentRow = {
+  id: string;
+  timeframe: string;
+  intent_tag: string;
+  expires_at: string;
+};
+
 export type UserProfilePayload = {
   user: {
     id: string;
@@ -26,9 +33,22 @@ export type UserProfilePayload = {
     preferred_activities?: string[];
     custom_status?: string | null;
   } | null;
+  /** Non-expired rows from `availability_intents` (when API can read them). */
+  availabilityIntents?: AvailabilityIntentRow[];
+  /** Logged-in viewer’s tags (for client-side use; API also sends `sharedInterestTags`). */
+  viewerInterestTags?: string[];
+  sharedInterestTags?: string[];
   /** Mutual `connections` row for viewer + profile user. */
   sharedConnection?: SharedConnectionPayload | null;
 };
+
+function humanizeTimeframe(value: string): string {
+  const s = value.trim();
+  if (!s) return '';
+  return s
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 function displayName(u: UserProfilePayload['user']): string {
   const fn = u.first_name?.trim();
@@ -285,38 +305,101 @@ export default function UserProfileModal({ userId, getAuthHeaders, onClose }: Us
                   </section>
 
                   <section>
-                    <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">Availability</h3>
-                    {!data.availability ? (
-                      <p className="text-sm text-zinc-500">No availability shared</p>
-                    ) : (
-                      <div className="space-y-2 text-sm text-zinc-300">
-                        <p>
-                          {data.availability.is_free_this_week
-                            ? 'Free this week'
-                            : 'Not marked free this week'}
-                        </p>
-                        {!!data.availability.available_days?.length && (
-                          <p className="text-zinc-400">
-                            <span className="text-zinc-500">Days: </span>
-                            {data.availability.available_days
-                              .map((d) => d.charAt(0).toUpperCase() + d.slice(1))
-                              .join(', ')}
-                          </p>
-                        )}
-                        {!!data.availability.preferred_activities?.length && (
-                          <p className="text-zinc-400">
-                            <span className="text-zinc-500">Activities: </span>
-                            {data.availability.preferred_activities.join(', ')}
-                          </p>
-                        )}
-                        {data.availability.custom_status && (
-                          <p className="text-zinc-200 border-l-2 border-[#8338EC]/50 pl-3">
-                            {data.availability.custom_status}
-                          </p>
-                        )}
-                      </div>
-                    )}
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">
+                      Availability
+                    </h3>
+                    {(() => {
+                      const intents = data.availabilityIntents ?? [];
+                      const hasLegacySchedule =
+                        !!data.availability &&
+                        (!!data.availability.available_days?.length ||
+                          !!data.availability.preferred_activities?.length ||
+                          !!data.availability.custom_status);
+
+                      if (intents.length === 0 && !hasLegacySchedule) {
+                        return (
+                          <p className="text-sm text-zinc-500">No availability shared yet</p>
+                        );
+                      }
+
+                      return (
+                        <div className="space-y-4 text-sm text-zinc-300">
+                          {intents.length > 0 ? (
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500 mb-2">
+                                Open to
+                              </p>
+                              <ul className="flex flex-col gap-2">
+                                {intents.map((row) => (
+                                  <li
+                                    key={row.id}
+                                    className="flex flex-wrap items-center gap-2 rounded-xl border border-zinc-800/90 bg-zinc-900/40 px-3 py-2"
+                                  >
+                                    <span className="rounded-full border border-[#3A86FF]/35 bg-[#3A86FF]/10 px-2.5 py-0.5 text-xs text-sky-200">
+                                      {row.intent_tag.trim()}
+                                    </span>
+                                    <span className="text-xs text-zinc-500">
+                                      {humanizeTimeframe(row.timeframe)}
+                                    </span>
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          ) : null}
+
+                          {hasLegacySchedule && data.availability ? (
+                            <div>
+                              <p className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500 mb-2">
+                                Schedule
+                              </p>
+                              <div className="space-y-2">
+                                {!!data.availability.available_days?.length && (
+                                  <p className="text-zinc-400">
+                                    <span className="text-zinc-500">Days: </span>
+                                    {data.availability.available_days
+                                      .map((d) => d.charAt(0).toUpperCase() + d.slice(1))
+                                      .join(', ')}
+                                  </p>
+                                )}
+                                {!!data.availability.preferred_activities?.length && (
+                                  <p className="text-zinc-400">
+                                    <span className="text-zinc-500">Activities: </span>
+                                    {data.availability.preferred_activities.join(', ')}
+                                  </p>
+                                )}
+                                {data.availability.custom_status && (
+                                  <p className="text-zinc-200 border-l-2 border-[#8338EC]/50 pl-3">
+                                    {data.availability.custom_status}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })()}
                   </section>
+
+                  {!!data.sharedInterestTags?.length && (
+                    <section>
+                      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">
+                        Shared interests
+                      </h3>
+                      <p className="text-[11px] text-zinc-500 mb-2">
+                        Conversation starters you both listed
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {data.sharedInterestTags.map((t) => (
+                          <span
+                            key={t}
+                            className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200"
+                          >
+                            {t}
+                          </span>
+                        ))}
+                      </div>
+                    </section>
+                  )}
                 </motion.div>
               )}
             </div>

--- a/components/chat/ChatView.tsx
+++ b/components/chat/ChatView.tsx
@@ -11,6 +11,7 @@ import {
   ChevronDown,
   MapPin,
   Calendar,
+  Sparkles,
   MoreHorizontal,
   Archive,
   UserMinus,
@@ -177,6 +178,7 @@ export default function ChatView({
   const [mediaBusy, setMediaBusy] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [recordingMs, setRecordingMs] = useState(0);
+  const [sharedInterestTags, setSharedInterestTags] = useState<string[]>([]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -310,6 +312,37 @@ export default function ChatView({
       deriveKeysForConnection(connection.id, userIds).then(setE2eKeys);
     }
   }, [connection.id, connection.userIds, connection.otherUserId, currentUserId]);
+
+  useEffect(() => {
+    if (!peerUserId) {
+      setSharedInterestTags([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const headers = await getAuthHeaders();
+        const res = await fetch(
+          `/api/users/${encodeURIComponent(peerUserId)}/profile`,
+          { headers },
+        );
+        const json = (await res.json().catch(() => ({}))) as {
+          sharedInterestTags?: unknown;
+        };
+        if (!res.ok || cancelled) return;
+        const raw = json.sharedInterestTags;
+        const tags = Array.isArray(raw)
+          ? raw.filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+          : [];
+        if (!cancelled) setSharedInterestTags(tags);
+      } catch {
+        if (!cancelled) setSharedInterestTags([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getAuthHeaders, peerUserId]);
 
   useEffect(() => {
     if (!replyingTo || replyingTo.message_type === 'call_log') {
@@ -1076,15 +1109,24 @@ export default function ChatView({
                   <button
                     onClick={async () => {
                       const success = await onUnarchive();
+                      const restored = connection.status === 'archived';
                       setActionToast(success
-                        ? { type: 'success', message: 'Conversation unarchived' }
-                        : { type: 'error', message: 'Could not unarchive conversation' }
+                        ? {
+                            type: 'success',
+                            message: restored ? 'Connection restored to active' : 'Conversation unarchived',
+                          }
+                        : {
+                            type: 'error',
+                            message: restored
+                              ? 'Could not restore connection'
+                              : 'Could not unarchive conversation',
+                          }
                       );
                       setShowHeaderMenu(false);
                     }}
                     className="w-full text-left px-3 py-2 text-sm text-[#7cc3ff] hover:bg-zinc-800"
                   >
-                    Unarchive
+                    {connection.status === 'archived' ? 'Restore' : 'Unarchive'}
                   </button>
                 ) : (
                   <button
@@ -1172,6 +1214,28 @@ export default function ChatView({
           </div>
         </div>
       </div>
+
+      {sharedInterestTags.length > 0 && (
+        <div className="glass mb-3 shrink-0 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-3">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-200/90">
+            <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            Conversation starters
+          </div>
+          <p className="mt-1 text-[11px] text-zinc-500">
+            Shared interests — try weaving one into your next message
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {sharedInterestTags.map((t) => (
+              <span
+                key={t}
+                className="rounded-full border border-emerald-500/35 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] text-emerald-100"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* ── Messages area ── */}
       <div

--- a/lib/dashboard/connectionStatus.ts
+++ b/lib/dashboard/connectionStatus.ts
@@ -53,6 +53,10 @@ export function normalizeConnectionStatus(row: Record<string, unknown>): Connect
   return 'pending';
 }
 
+/** PostgREST `.or()` filter for rows visible in the main connections / chat list (matches GET default). */
+export const ACTIVE_CONNECTIONS_DB_OR_FILTER =
+  'status.is.null,status.eq.pending,status.eq.active,status.eq.kept';
+
 /** Shown in active chat lists (not removed/archived by server or legacy expired). */
 export function isActiveChatListStatus(status: ConnectionDisplayStatus): boolean {
   if (status === 'removed' || status === 'archived' || status === 'expired') return false;

--- a/lib/userProfile/sharedInterests.ts
+++ b/lib/userProfile/sharedInterests.ts
@@ -1,0 +1,29 @@
+/**
+ * Compare two interest tag lists (e.g. from `user_interests.tags`) and return
+ * shared tags for conversation starters. Matching is case-insensitive; output
+ * preserves the first-seen casing from `viewerTags`.
+ */
+export function getSharedInterestTags(viewerTags: string[], peerTags: string[]): string[] {
+  if (!viewerTags.length || !peerTags.length) return [];
+
+  const peerLower = new Map<string, string>();
+  for (const t of peerTags) {
+    const s = typeof t === 'string' ? t.trim() : '';
+    if (!s) continue;
+    const k = s.toLowerCase();
+    if (!peerLower.has(k)) peerLower.set(k, s);
+  }
+  if (peerLower.size === 0) return [];
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of viewerTags) {
+    const s = typeof t === 'string' ? t.trim() : '';
+    if (!s) continue;
+    const k = s.toLowerCase();
+    if (!peerLower.has(k) || seen.has(k)) continue;
+    seen.add(k);
+    out.push(s);
+  }
+  return out;
+}

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -69,3 +69,6 @@ UPDATE public.connections
 SET status = 'active'
 WHERE status IS NULL AND COALESCE(has_begun, false) = true AND expiry_state IS DISTINCT FROM 'kept';
 
+-- `availability_intents` (see migrations) is owner-only by default. For profile surfaces that
+-- list another user’s intents, add a read policy (e.g. mutual connection) or use a service-role
+-- API route — `/api/users/[userId]/profile` uses the service role when configured.

--- a/types/database-connections.ts
+++ b/types/database-connections.ts
@@ -1,0 +1,28 @@
+/**
+ * Documented shapes for `public.connections` used by the web app and API.
+ * Regenerate from Supabase CLI when the schema changes.
+ */
+import type { ConnectionLifecycleStatus } from '@/types/connection';
+
+export type ConnectionLifecycleStatusColumn = ConnectionLifecycleStatus;
+
+/** Row shape returned by `/api/connections` (subset used on the client). */
+export type ConnectionsApiRow = {
+  id: string;
+  user_ids: string[];
+  status: ConnectionLifecycleStatus | null;
+  created?: number | null;
+  created_utc?: string | null;
+  created_at?: string | null;
+  last_message_at?: number | null;
+  has_begun?: boolean | null;
+  expiry_state?: string | null;
+  semantic_location?: string | null;
+  full_location?: string | null;
+  geo_location?: Record<string, unknown> | null;
+  memory_capsule?: unknown;
+  context_tag_id?: string | null;
+  weather_condition?: string | null;
+  noise_level?: string | null;
+  [key: string]: unknown;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the web dashboard with mobile connection lifecycle and profile data: server `archived` rows surface in the chat Archived tab, GET `/api/connections` can target archived scope, restore uses PATCH, direct Supabase loads mirror the active filter, and profiles show `availability_intents` plus shared interest tags for icebreakers.

## Changes

- **Connections API**: Default GET keeps `pending` / `active` / `kept` plus legacy `null` status via shared `ACTIVE_CONNECTIONS_DB_OR_FILTER`. Optional `?statusScope=archived` returns `status = archived`. New **PATCH** `{ action: 'restore', connectionId }` sets `status` back to `active` (participant check + service role).
- **Dashboard**: `loadConnections` runs two queries (active OR filter + archived) and merges by id so Memory Box / map / metrics stay complete while chat list logic can split. Chat metadata loads for `archived` too. Archived tab = union of server-archived and user `connection_archives` rows; badges distinguish **Auto-archived** vs **Archived**. **Restore** / **Unarchive** calls PATCH when the row is server-archived.
- **Profile API & modal**: Fetches non-expired `availability_intents` (service role when set), returns `sharedInterestTags` from `getSharedInterestTags`. Modal shows an **Open to** list (intent + timeframe) and drops the old static “free this week” line; legacy `user_availability` schedule still shows when present.
- **Chat**: **Conversation starters** strip when `sharedInterestTags` from profile API is non-empty.
- **Types**: `types/database-connections.ts` documents connection row shapes; `supabase-setup.sql` comment on intents visibility.

## Testing

- `npm test`
- `npm run build`

## Notes

- Restoring archived connections requires `SUPABASE_SERVICE_ROLE_KEY` on the server (same pattern as DELETE). Without it, PATCH may fail against RLS.
- Reading peers’ `availability_intents` in profile uses the service role when configured; otherwise intents may be empty until DB policy allows mutual reads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c53e58d-01fb-4af3-9a06-8d24e0901cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c53e58d-01fb-4af3-9a06-8d24e0901cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lightningbolts/click-web/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
