### PR TITLE
Dashboard: junction-based connection visibility and availability intents

### DIFF
--- a/__tests__/lib/userProfile/availabilityIntentDisplay.test.ts
+++ b/__tests__/lib/userProfile/availabilityIntentDisplay.test.ts
@@ -1,0 +1,23 @@
+import { humanizeAvailabilityTimeframe } from '@/lib/userProfile/availabilityIntentDisplay';
+
+describe('humanizeAvailabilityTimeframe', () => {
+  it('formats ~24h ISO interval as Next 24h', () => {
+    expect(
+      humanizeAvailabilityTimeframe(
+        '2026-04-08T18:00:00.000Z/2026-04-09T18:00:00.000Z',
+      ),
+    ).toBe('Next 24h');
+  });
+
+  it('formats other intervals as Until {end date}', () => {
+    expect(
+      humanizeAvailabilityTimeframe(
+        '2026-04-08T12:00:00.000Z/2026-04-08T15:00:00.000Z',
+      ),
+    ).toBe('Until Apr 8');
+  });
+
+  it('falls back to title-cased legacy tokens', () => {
+    expect(humanizeAvailabilityTimeframe('this_week')).toBe('This Week');
+  });
+});

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -241,8 +241,9 @@ function filterConnectionsByVisibility(
   return rows.filter((row) => {
     const id = typeof row.id === 'string' ? row.id : '';
     if (!id || hiddenIds.has(id)) return false;
-    if (mode === 'active') return !archivedIds.has(id);
-    return archivedIds.has(id);
+    const isLegacyArchived = row.status === 'archived';
+    if (mode === 'active') return !archivedIds.has(id) && !isLegacyArchived;
+    return archivedIds.has(id) || isLegacyArchived;
   });
 }
 
@@ -332,8 +333,14 @@ export async function GET(request: NextRequest) {
       .contains('user_ids', [user.id])
       .order('created', { ascending: false });
 
+    const scope = searchParams.get(STATUS_SCOPE_PARAM)?.toLowerCase();
+
     if (!insights) {
-      query = query.or(ACTIVE_CONNECTIONS_DB_OR_FILTER);
+      if (scope === 'archived') {
+        query = query.or(`${ACTIVE_CONNECTIONS_DB_OR_FILTER},status.eq.archived`);
+      } else {
+        query = query.or(ACTIVE_CONNECTIONS_DB_OR_FILTER);
+      }
     }
 
     const { data: connectionsRaw, error } = await query;
@@ -355,7 +362,6 @@ export async function GET(request: NextRequest) {
       fetchConnectionIdsForUser(adminClient, 'connection_archives', user.id),
     ]);
 
-    const scope = searchParams.get(STATUS_SCOPE_PARAM)?.toLowerCase();
     const mode = scope === 'archived' ? 'archived' : 'active';
     const connections = filterConnectionsByVisibility(rows, hiddenIds, archivedIds, mode);
 

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -588,15 +588,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: existingErr.message }, { status: 500 });
     }
 
-    const hiddenForUser = await fetchConnectionIdsForUser(
-      adminClient,
-      'connection_hidden',
-      user.id,
-    );
-
+    // Per-user `connection_hidden` must not allow a second row: the connection is shared;
+    // the other party would still see the original. Reconnect after hide requires un-hiding
+    // or a dedicated product flow, not a duplicate insert.
     const blocksNewConnection = (existingRows ?? []).some((r) => {
-      const id = typeof r.id === 'string' ? r.id : '';
-      if (!id || hiddenForUser.has(id)) return false;
       const s = r.status as string | null | undefined;
       return s !== 'removed' && s !== 'archived';
     });

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -10,7 +10,10 @@ import { ACTIVE_CONNECTIONS_DB_OR_FILTER } from '@/lib/dashboard/connectionStatu
  *
  * GET    → Fetch connections for the authenticated user
  * POST   → Create a new connection with proximity validation (Layers 2 & 3)
- * DELETE → Soft-remove: set `status` to `removed` (retains row for analytics)
+ * DELETE → Per-user hide: insert `connection_hidden` (no `connections` row delete)
+ *
+ * Visibility uses junction tables `connection_archives` and `connection_hidden`, not
+ * `connections.status` values `archived` / `removed`.
  */
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -210,6 +213,39 @@ function toIconCode(weatherCode: number): string {
   return 'clear';
 }
 
+async function fetchConnectionIdsForUser(
+  adminClient: ReturnType<typeof createAdminClient>,
+  table: 'connection_archives' | 'connection_hidden',
+  userId: string,
+): Promise<Set<string>> {
+  const { data, error } = await adminClient.from(table).select('connection_id').eq('user_id', userId);
+  if (error) {
+    console.error(`connections API: ${table} lookup`, error);
+    return new Set();
+  }
+  return new Set(
+    (data ?? [])
+      .map((row: { connection_id?: string }) =>
+        typeof row.connection_id === 'string' ? row.connection_id : '',
+      )
+      .filter(Boolean),
+  );
+}
+
+function filterConnectionsByVisibility(
+  rows: Record<string, unknown>[],
+  hiddenIds: Set<string>,
+  archivedIds: Set<string>,
+  mode: 'active' | 'archived',
+): Record<string, unknown>[] {
+  return rows.filter((row) => {
+    const id = typeof row.id === 'string' ? row.id : '';
+    if (!id || hiddenIds.has(id)) return false;
+    if (mode === 'active') return !archivedIds.has(id);
+    return archivedIds.has(id);
+  });
+}
+
 async function enrichMemoryCapsuleWeather(
   adminClient: ReturnType<typeof createAdminClient>,
   connectionId: string,
@@ -290,8 +326,6 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const insights = isInsightsScope(searchParams);
 
-    // Active dashboard/chat views omit auto-archived and user-removed rows.
-    // Archived tab: `?statusScope=archived`. Insights: `?includeInsights=1` for every lifecycle state.
     let query = supabase
       .from('connections')
       .select('*')
@@ -299,22 +333,33 @@ export async function GET(request: NextRequest) {
       .order('created', { ascending: false });
 
     if (!insights) {
-      const scope = searchParams.get(STATUS_SCOPE_PARAM)?.toLowerCase();
-      if (scope === 'archived') {
-        query = query.eq('status', 'archived');
-      } else {
-        query = query.or(ACTIVE_CONNECTIONS_DB_OR_FILTER);
-      }
+      query = query.or(ACTIVE_CONNECTIONS_DB_OR_FILTER);
     }
 
-    const { data: connections, error } = await query;
+    const { data: connectionsRaw, error } = await query;
 
     if (error) {
       console.error('Error fetching connections:', error);
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
 
-    return NextResponse.json({ connections: connections || [] });
+    const rows = (connectionsRaw ?? []) as Record<string, unknown>[];
+
+    if (insights) {
+      return NextResponse.json({ connections: rows });
+    }
+
+    const adminClient = createAdminClient();
+    const [hiddenIds, archivedIds] = await Promise.all([
+      fetchConnectionIdsForUser(adminClient, 'connection_hidden', user.id),
+      fetchConnectionIdsForUser(adminClient, 'connection_archives', user.id),
+    ]);
+
+    const scope = searchParams.get(STATUS_SCOPE_PARAM)?.toLowerCase();
+    const mode = scope === 'archived' ? 'archived' : 'active';
+    const connections = filterConnectionsByVisibility(rows, hiddenIds, archivedIds, mode);
+
+    return NextResponse.json({ connections });
   } catch (error) {
     console.error('Server error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
@@ -371,24 +416,42 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: 'Connection not found' }, { status: 404 });
     }
 
-    if (row.status !== 'archived') {
-      return NextResponse.json(
-        { error: 'Only archived connections can be restored' },
-        { status: 409 },
-      );
+    const { error: delArchiveErr } = await adminClient
+      .from('connection_archives')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('connection_id', connectionId);
+
+    if (delArchiveErr) {
+      console.error('Connection restore (archive junction) error:', delArchiveErr);
+      return NextResponse.json({ error: delArchiveErr.message }, { status: 400 });
     }
 
-    const activeStatus: ConnectionLifecycleStatus = 'active';
-    const { data: updated, error: updateError } = await adminClient
-      .from('connections')
-      .update({ status: activeStatus })
-      .eq('id', connectionId)
-      .select()
-      .maybeSingle();
-
-    if (updateError) {
-      console.error('Connection restore error:', updateError);
-      return NextResponse.json({ error: updateError.message }, { status: 400 });
+    let updated: Record<string, unknown> | null = null;
+    if (row.status === 'archived') {
+      const activeStatus: ConnectionLifecycleStatus = 'active';
+      const { data: rowUpdated, error: updateError } = await adminClient
+        .from('connections')
+        .update({ status: activeStatus })
+        .eq('id', connectionId)
+        .select()
+        .maybeSingle();
+      if (updateError) {
+        console.error('Connection restore status error:', updateError);
+        return NextResponse.json({ error: updateError.message }, { status: 400 });
+      }
+      updated = rowUpdated as Record<string, unknown> | null;
+    } else {
+      const { data: refreshed, error: fetchErr } = await adminClient
+        .from('connections')
+        .select('*')
+        .eq('id', connectionId)
+        .maybeSingle();
+      if (fetchErr) {
+        console.error('Connection restore fetch error:', fetchErr);
+        return NextResponse.json({ error: fetchErr.message }, { status: 400 });
+      }
+      updated = refreshed as Record<string, unknown> | null;
     }
 
     return NextResponse.json({ success: true, connection: updated });
@@ -398,7 +461,7 @@ export async function PATCH(request: NextRequest) {
   }
 }
 
-// ─── DELETE — soft remove (status = removed) ─────────────────────────────────
+// ─── DELETE — per-user hide (`connection_hidden`) ────────────────────────────
 
 export async function DELETE(request: NextRequest) {
   try {
@@ -416,11 +479,12 @@ export async function DELETE(request: NextRequest) {
     }
 
     const adminClient = createAdminClient();
+    const cid = connectionId.trim();
 
     const { data: row, error: fetchError } = await adminClient
       .from('connections')
       .select('id, user_ids')
-      .eq('id', connectionId.trim())
+      .eq('id', cid)
       .maybeSingle();
 
     if (fetchError) {
@@ -433,17 +497,34 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Connection not found' }, { status: 404 });
     }
 
-    const removedStatus: ConnectionLifecycleStatus = 'removed';
-    const { data: updated, error: updateError } = await adminClient
+    const { error: delArchiveErr } = await adminClient
+      .from('connection_archives')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('connection_id', cid);
+    if (delArchiveErr) {
+      console.error('connection_archives cleanup on hide:', delArchiveErr);
+    }
+
+    const { error: insertErr } = await adminClient.from('connection_hidden').insert({
+      user_id: user.id,
+      connection_id: cid,
+    });
+
+    if (insertErr && insertErr.code !== '23505') {
+      console.error('connection_hidden insert error:', insertErr);
+      return NextResponse.json({ error: insertErr.message }, { status: 400 });
+    }
+
+    const { data: updated, error: refetchErr } = await adminClient
       .from('connections')
-      .update({ status: removedStatus })
-      .eq('id', connectionId.trim())
-      .select()
+      .select('*')
+      .eq('id', cid)
       .maybeSingle();
 
-    if (updateError) {
-      console.error('Connection soft-delete error:', updateError);
-      return NextResponse.json({ error: updateError.message }, { status: 400 });
+    if (refetchErr) {
+      console.error('Connection refetch after hide:', refetchErr);
+      return NextResponse.json({ error: refetchErr.message }, { status: 400 });
     }
 
     return NextResponse.json({ success: true, connection: updated });
@@ -507,7 +588,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: existingErr.message }, { status: 500 });
     }
 
+    const hiddenForUser = await fetchConnectionIdsForUser(
+      adminClient,
+      'connection_hidden',
+      user.id,
+    );
+
     const blocksNewConnection = (existingRows ?? []).some((r) => {
+      const id = typeof r.id === 'string' ? r.id : '';
+      if (!id || hiddenForUser.has(id)) return false;
       const s = r.status as string | null | undefined;
       return s !== 'removed' && s !== 'archived';
     });

--- a/app/api/me/availability-intents/route.ts
+++ b/app/api/me/availability-intents/route.ts
@@ -1,0 +1,157 @@
+/**
+ * GET /api/me/availability-intents — current non-expired intents + last_intent_update_at
+ * PATCH /api/me/availability-intents — replace intents and bump last_intent_update_at
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { getAuthenticatedSupabase } from '@/lib/server/supabaseAuth';
+
+function createAdminClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+const MAX_INTENTS = 12;
+const MAX_TAG_LEN = 25;
+
+type IncomingIntent = {
+  timeframe?: string;
+  intent_tag?: string;
+  expires_at?: string;
+};
+
+export async function GET(req: NextRequest) {
+  const { user } = await getAuthenticatedSupabase(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+
+  const [{ data: userRow, error: userErr }, { data: intentRows, error: intentErr }] = await Promise.all([
+    admin.from('users').select('last_intent_update_at').eq('id', user.id).maybeSingle(),
+    admin
+      .from('availability_intents')
+      .select('id, timeframe, intent_tag, expires_at')
+      .eq('user_id', user.id)
+      .gt('expires_at', nowIso)
+      .order('expires_at', { ascending: true }),
+  ]);
+
+  if (userErr) {
+    return NextResponse.json({ error: userErr.message }, { status: 400 });
+  }
+  if (intentErr) {
+    return NextResponse.json({ error: intentErr.message }, { status: 400 });
+  }
+
+  const last_intent_update_at =
+    userRow && typeof (userRow as { last_intent_update_at?: string }).last_intent_update_at === 'string'
+      ? (userRow as { last_intent_update_at: string }).last_intent_update_at
+      : null;
+
+  return NextResponse.json({
+    last_intent_update_at,
+    intents: intentRows ?? [],
+  });
+}
+
+function normalizeIntents(body: unknown): { timeframe: string; intent_tag: string; expires_at: string }[] | null {
+  if (!body || typeof body !== 'object') return null;
+  const raw = (body as { intents?: unknown }).intents;
+  if (!Array.isArray(raw)) return null;
+  const out: { timeframe: string; intent_tag: string; expires_at: string }[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as IncomingIntent;
+    const timeframe = typeof o.timeframe === 'string' ? o.timeframe.trim() : '';
+    const intent_tag = typeof o.intent_tag === 'string' ? o.intent_tag.trim().slice(0, MAX_TAG_LEN) : '';
+    const expires_at = typeof o.expires_at === 'string' ? o.expires_at.trim() : '';
+    if (!timeframe || !intent_tag || !expires_at) continue;
+    const expMs = Date.parse(expires_at);
+    if (!Number.isFinite(expMs) || expMs <= Date.now()) continue;
+    out.push({ timeframe, intent_tag, expires_at });
+    if (out.length >= MAX_INTENTS) break;
+  }
+  return out;
+}
+
+export async function PATCH(req: NextRequest) {
+  const { user } = await getAuthenticatedSupabase(req);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const intents = normalizeIntents(body);
+  if (intents === null) {
+    return NextResponse.json({ error: 'intents array required' }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+
+  const { error: delErr } = await admin
+    .from('availability_intents')
+    .delete()
+    .eq('user_id', user.id)
+    .gt('expires_at', nowIso);
+
+  if (delErr) {
+    console.error('availability_intents delete:', delErr);
+    return NextResponse.json({ error: delErr.message }, { status: 400 });
+  }
+
+  if (intents.length > 0) {
+    const rows = intents.map((i) => ({
+      user_id: user.id,
+      timeframe: i.timeframe,
+      intent_tag: i.intent_tag,
+      expires_at: i.expires_at,
+    }));
+    const { error: insErr } = await admin.from('availability_intents').insert(rows);
+    if (insErr) {
+      console.error('availability_intents insert:', insErr);
+      return NextResponse.json({ error: insErr.message }, { status: 400 });
+    }
+  }
+
+  const { error: userErr } = await admin
+    .from('users')
+    .update({ last_intent_update_at: nowIso })
+    .eq('id', user.id);
+
+  if (userErr) {
+    console.error('users last_intent_update_at:', userErr);
+    return NextResponse.json({ error: userErr.message }, { status: 400 });
+  }
+
+  const { data: refreshed, error: fetchErr } = await admin
+    .from('availability_intents')
+    .select('id, timeframe, intent_tag, expires_at')
+    .eq('user_id', user.id)
+    .gt('expires_at', nowIso)
+    .order('expires_at', { ascending: true });
+
+  if (fetchErr) {
+    return NextResponse.json({ error: fetchErr.message }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    last_intent_update_at: nowIso,
+    intents: refreshed ?? [],
+  });
+}

--- a/app/api/users/[userId]/profile/route.ts
+++ b/app/api/users/[userId]/profile/route.ts
@@ -40,7 +40,7 @@ export async function GET(
     const [userRes, interestsRes, availRes] = await Promise.all([
       supabase
         .from('users')
-        .select('id, first_name, last_name, name, full_name, birthday, image, email')
+        .select('id, first_name, last_name, name, full_name, birthday, image, email, last_intent_update_at')
         .eq('id', userId)
         .maybeSingle(),
       supabase.from('user_interests').select('tags').eq('user_id', userId).maybeSingle(),
@@ -49,20 +49,34 @@ export async function GET(
 
     const profileTags = (interestsRes.data as { tags?: string[] } | null)?.tags ?? [];
 
+    const lastIntentUpdateAt =
+      userRes.data &&
+      typeof (userRes.data as { last_intent_update_at?: string }).last_intent_update_at === 'string'
+        ? (userRes.data as { last_intent_update_at: string }).last_intent_update_at
+        : null;
+
+    const MS_24H = 24 * 60 * 60 * 1000;
+    const intentSweepExpired =
+      !!lastIntentUpdateAt &&
+      Number.isFinite(Date.parse(lastIntentUpdateAt)) &&
+      Date.now() - Date.parse(lastIntentUpdateAt) >= MS_24H;
+
     let availabilityIntents: AvailabilityIntentPayload[] = [];
     try {
-      const admin = createAdminClient();
-      const { data: intentRows, error: intentErr } = await admin
-        .from('availability_intents')
-        .select('id, timeframe, intent_tag, expires_at')
-        .eq('user_id', userId)
-        .gt('expires_at', new Date().toISOString())
-        .order('expires_at', { ascending: true });
+      if (!intentSweepExpired) {
+        const admin = createAdminClient();
+        const { data: intentRows, error: intentErr } = await admin
+          .from('availability_intents')
+          .select('id, timeframe, intent_tag, expires_at')
+          .eq('user_id', userId)
+          .gt('expires_at', new Date().toISOString())
+          .order('expires_at', { ascending: true });
 
-      if (!intentErr && intentRows) {
-        availabilityIntents = intentRows as AvailabilityIntentPayload[];
-      } else if (intentErr) {
-        console.warn('profile availability_intents:', intentErr.message);
+        if (!intentErr && intentRows) {
+          availabilityIntents = intentRows as AvailabilityIntentPayload[];
+        } else if (intentErr) {
+          console.warn('profile availability_intents:', intentErr.message);
+        }
       }
     } catch (e) {
       console.warn('profile availability_intents fetch failed:', e);
@@ -113,6 +127,8 @@ export async function GET(
       tags: profileTags,
       availability: availRes.data ?? null,
       availabilityIntents,
+      last_intent_update_at: lastIntentUpdateAt,
+      intent_sweep_expired: intentSweepExpired,
       viewerInterestTags,
       sharedInterestTags,
       sharedConnection,

--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -1156,15 +1156,9 @@ export default function DashboardView({ user }: DashboardViewProps) {
 
     try {
       const headers = await getAuthHeaders();
-      const [activeRes, archivedRes, legacyArchivedRes] = await Promise.all([
+      const [activeRes, archivedRes] = await Promise.all([
         fetch('/api/connections', { headers }),
         fetch('/api/connections?statusScope=archived', { headers }),
-        supabase
-          .from('connections')
-          .select('*')
-          .contains('user_ids', [user.id])
-          .eq('status', 'archived')
-          .order('created', { ascending: false }),
       ]);
 
       const activeJson = await activeRes.json().catch(() => ({}));
@@ -1182,10 +1176,6 @@ export default function DashboardView({ user }: DashboardViewProps) {
 
       const activeRows = (activeJson.connections ?? []) as Record<string, unknown>[];
       const archivedRows = (archivedJson.connections ?? []) as Record<string, unknown>[];
-      const legacyArchivedRows =
-        !legacyArchivedRes.error && legacyArchivedRes.data
-          ? (legacyArchivedRes.data as Record<string, unknown>[])
-          : [];
 
       const mergedById = new Map<string, Record<string, unknown>>();
       for (const row of activeRows) {
@@ -1193,10 +1183,6 @@ export default function DashboardView({ user }: DashboardViewProps) {
         if (typeof id === 'string') mergedById.set(id, row);
       }
       for (const row of archivedRows) {
-        const id = row.id;
-        if (typeof id === 'string' && !mergedById.has(id)) mergedById.set(id, row);
-      }
-      for (const row of legacyArchivedRows) {
         const id = row.id;
         if (typeof id === 'string' && !mergedById.has(id)) mergedById.set(id, row);
       }

--- a/components/DashboardView.tsx
+++ b/components/DashboardView.tsx
@@ -43,6 +43,7 @@ import CallOverlay, {
 } from '@/components/chat/CallOverlay';
 import UserProfileModal from '@/components/UserProfileModal';
 import PostConnectionVibePrompt from '@/components/dashboard/PostConnectionVibePrompt';
+import CurrentAvailabilitySection from '@/components/dashboard/CurrentAvailabilitySection';
 
 /** Matches `CallPushNotifier.kt` → `send-push-notification` for `incoming_call` / VoIP wake-up. */
 function buildIncomingCallPushPayload(invite: WebCallInvite) {
@@ -88,7 +89,6 @@ import {
   normalizeNoiseCategory,
 } from '@/lib/dashboard/connectionExtras';
 import {
-  ACTIVE_CONNECTIONS_DB_OR_FILTER,
   connectionRecordToArchiveRow,
   formatArchiveCountdownLabel,
   getArchiveCountdown,
@@ -132,13 +132,13 @@ export default function DashboardView({ user }: DashboardViewProps) {
   /** The connection whose chat is currently open, or null */
   const [selectedConnection, setSelectedConnection] = useState<ConnectionRecord | null>(null);
   const [chatListTab, setChatListTab] = useState<'active' | 'archived'>('active');
-  const [archivedConnectionIds, setArchivedConnectionIds] = useState<Set<string>>(new Set());
+  /** Per-user rows in `connection_archives` (relational archive, not `connections.status`). */
+  const [junctionArchivedConnectionIds, setJunctionArchivedConnectionIds] = useState<Set<string>>(new Set());
   const [blockedUserIds, setBlockedUserIds] = useState<Set<string>>(new Set());
   const [menuConnectionId, setMenuConnectionId] = useState<string | null>(null);
   const [suppressClickConnectionId, setSuppressClickConnectionId] = useState<string | null>(null);
   const [vibePromptConnection, setVibePromptConnection] = useState<ConnectionRecord | null>(null);
   const seenConnectionIdsRef = useRef<Set<string> | null>(null);
-  const [archiveTableAvailable, setArchiveTableAvailable] = useState(true);
   const [chatMetadataByConnectionId, setChatMetadataByConnectionId] = useState<Record<string, ChatListMetadata>>({});
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [callOverlayState, setCallOverlayState] = useState<WebCallOverlayState>(IDLE_CALL_OVERLAY);
@@ -1155,38 +1155,48 @@ export default function DashboardView({ user }: DashboardViewProps) {
     };
 
     try {
-      const activeQuery = supabase
-        .from('connections')
-        .select('*')
-        .contains('user_ids', [user.id])
-        .or(ACTIVE_CONNECTIONS_DB_OR_FILTER)
-        .order('created', { ascending: false });
+      const headers = await getAuthHeaders();
+      const [activeRes, archivedRes, legacyArchivedRes] = await Promise.all([
+        fetch('/api/connections', { headers }),
+        fetch('/api/connections?statusScope=archived', { headers }),
+        supabase
+          .from('connections')
+          .select('*')
+          .contains('user_ids', [user.id])
+          .eq('status', 'archived')
+          .order('created', { ascending: false }),
+      ]);
 
-      const archivedQuery = supabase
-        .from('connections')
-        .select('*')
-        .contains('user_ids', [user.id])
-        .eq('status', 'archived')
-        .order('created', { ascending: false });
+      const activeJson = await activeRes.json().catch(() => ({}));
+      const archivedJson = await archivedRes.json().catch(() => ({}));
 
-      const [activeRes, archivedRes] = await Promise.all([activeQuery, archivedQuery]);
-
-      if (activeRes.error) {
-        console.error('Error fetching connections:', activeRes.error.message || activeRes.error);
+      if (!activeRes.ok) {
+        console.error('Error fetching connections:', activeJson.error || activeRes.statusText);
         setEmptyConnections();
         return;
       }
 
-      if (archivedRes.error) {
-        console.warn('Archived connections fetch skipped:', archivedRes.error.message || archivedRes.error);
+      if (!archivedRes.ok) {
+        console.warn('Archived connections fetch skipped:', archivedJson.error || archivedRes.statusText);
       }
 
+      const activeRows = (activeJson.connections ?? []) as Record<string, unknown>[];
+      const archivedRows = (archivedJson.connections ?? []) as Record<string, unknown>[];
+      const legacyArchivedRows =
+        !legacyArchivedRes.error && legacyArchivedRes.data
+          ? (legacyArchivedRes.data as Record<string, unknown>[])
+          : [];
+
       const mergedById = new Map<string, Record<string, unknown>>();
-      for (const row of (activeRes.data ?? []) as Record<string, unknown>[]) {
+      for (const row of activeRows) {
         const id = row.id;
         if (typeof id === 'string') mergedById.set(id, row);
       }
-      for (const row of (archivedRes.data ?? []) as Record<string, unknown>[]) {
+      for (const row of archivedRows) {
+        const id = row.id;
+        if (typeof id === 'string' && !mergedById.has(id)) mergedById.set(id, row);
+      }
+      for (const row of legacyArchivedRows) {
         const id = row.id;
         if (typeof id === 'string' && !mergedById.has(id)) mergedById.set(id, row);
       }
@@ -1319,6 +1329,16 @@ export default function DashboardView({ user }: DashboardViewProps) {
 
       setConnectionRecords(records);
       setChapters(generateChaptersFromConnections(records));
+
+      const junctionArchived = new Set<string>();
+      for (const row of archivedRows) {
+        const id = row.id;
+        if (typeof id === 'string') junctionArchived.add(id);
+      }
+      for (const rec of records) {
+        if (rec.status === 'archived') junctionArchived.add(rec.id);
+      }
+      setJunctionArchivedConnectionIds(junctionArchived);
     } catch (err) {
       console.error('Unexpected error fetching connections:', err);
       setEmptyConnections();
@@ -1391,97 +1411,6 @@ export default function DashboardView({ user }: DashboardViewProps) {
   const userName =
     displayNameFromUserMetadata(user?.user_metadata) || user?.email?.split('@')[0] || 'User';
 
-  const archiveStorageKey = user?.id ? `click:archived-connections:${user.id}` : null;
-
-  const isMissingArchiveTableError = useCallback((error: any) => {
-    const code = error?.code;
-    const message = String(error?.message || '').toLowerCase();
-    return code === 'PGRST205' ||
-      message.includes('connection_archives') ||
-      message.includes('schema cache');
-  }, []);
-
-  const writeArchivedToLocalStorage = useCallback((ids: Set<string>) => {
-    if (!archiveStorageKey || typeof window === 'undefined') return;
-    localStorage.setItem(archiveStorageKey, JSON.stringify(Array.from(ids)));
-  }, [archiveStorageKey]);
-
-  useEffect(() => {
-    if (!user?.id) return;
-
-    const loadArchived = async () => {
-      const supabase = getSupabaseClient();
-      if (!supabase) {
-        if (archiveStorageKey && typeof window !== 'undefined') {
-          const raw = localStorage.getItem(archiveStorageKey);
-          if (raw) {
-            try {
-              setArchivedConnectionIds(new Set(JSON.parse(raw)));
-            } catch {
-              setArchivedConnectionIds(new Set());
-            }
-          }
-        }
-        return;
-      }
-
-      try {
-        if (!archiveTableAvailable) {
-          if (archiveStorageKey && typeof window !== 'undefined') {
-            const raw = localStorage.getItem(archiveStorageKey);
-            if (raw) {
-              try {
-                setArchivedConnectionIds(new Set(JSON.parse(raw)));
-              } catch {
-                setArchivedConnectionIds(new Set());
-              }
-            }
-          }
-          return;
-        }
-
-        const { data, error } = await supabase
-          .from('connection_archives')
-          .select('connection_id')
-          .eq('user_id', user.id);
-
-        if (error) {
-          if (isMissingArchiveTableError(error)) {
-            setArchiveTableAvailable(false);
-          }
-          if (archiveStorageKey && typeof window !== 'undefined') {
-            const raw = localStorage.getItem(archiveStorageKey);
-            if (raw) {
-              try {
-                setArchivedConnectionIds(new Set(JSON.parse(raw)));
-              } catch {
-                setArchivedConnectionIds(new Set());
-              }
-            }
-          }
-          return;
-        }
-
-        const ids = new Set<string>((data ?? []).map((row: any) => row.connection_id));
-        setArchivedConnectionIds(ids);
-        writeArchivedToLocalStorage(ids);
-      } catch {
-        if (archiveStorageKey && typeof window !== 'undefined') {
-          const raw = localStorage.getItem(archiveStorageKey);
-          if (raw) {
-            try {
-              setArchivedConnectionIds(new Set(JSON.parse(raw)));
-            } catch {
-              setArchivedConnectionIds(new Set());
-            }
-          }
-        }
-      }
-    };
-
-    loadArchived();
-  }, [archiveStorageKey, archiveTableAvailable, isMissingArchiveTableError, user?.id, writeArchivedToLocalStorage]);
-
   useEffect(() => {
     const id = setInterval(() => setArchiveCountdownTick((t) => t + 1), 60_000);
     return () => clearInterval(id);
@@ -1539,16 +1468,12 @@ export default function DashboardView({ user }: DashboardViewProps) {
     };
   }, []);
 
-  const updateArchivedIds = useCallback((updater: (prev: Set<string>) => Set<string>) => {
-    setArchivedConnectionIds((prev) => {
-      const next = updater(prev);
-      writeArchivedToLocalStorage(next);
-      return next;
-    });
-  }, [writeArchivedToLocalStorage]);
+  const updateJunctionArchivedIds = useCallback((updater: (prev: Set<string>) => Set<string>) => {
+    setJunctionArchivedConnectionIds(updater);
+  }, []);
 
   const archiveConnection = useCallback(async (connectionId: string): Promise<boolean> => {
-    updateArchivedIds((prev) => {
+    updateJunctionArchivedIds((prev) => {
       const next = new Set(prev);
       next.add(connectionId);
       return next;
@@ -1556,30 +1481,36 @@ export default function DashboardView({ user }: DashboardViewProps) {
     setMenuConnectionId(null);
 
     const supabase = getSupabaseClient();
-    if (!supabase || !user?.id || !archiveTableAvailable) return true;
+    if (!supabase || !user?.id) return true;
     try {
       const { error } = await supabase
         .from('connection_archives')
         .insert({ user_id: user.id, connection_id: connectionId });
 
       if (error && error.code !== '23505') {
-        if (isMissingArchiveTableError(error)) {
-          setArchiveTableAvailable(false);
-          return true;
-        }
         console.error('Error archiving connection:', error.message || error);
+        updateJunctionArchivedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(connectionId);
+          return next;
+        });
         return false;
       }
       return true;
     } catch (err) {
       console.error('Unexpected archive error:', err);
+      updateJunctionArchivedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
       return false;
     }
-  }, [archiveTableAvailable, isMissingArchiveTableError, updateArchivedIds, user?.id]);
+  }, [updateJunctionArchivedIds, user?.id]);
 
   const unarchiveConnection = useCallback(
-    async (connectionId: string, rowStatus?: ConnectionRecord['status']): Promise<boolean> => {
-      updateArchivedIds((prev) => {
+    async (connectionId: string, _rowStatus?: ConnectionRecord['status']): Promise<boolean> => {
+      updateJunctionArchivedIds((prev) => {
         const next = new Set(prev);
         next.delete(connectionId);
         return next;
@@ -1587,62 +1518,36 @@ export default function DashboardView({ user }: DashboardViewProps) {
       setMenuConnectionId(null);
       setChatListTab('active');
 
-      const fromRecord = connectionRecords.find((c) => c.id === connectionId);
-      const effectiveStatus = rowStatus ?? fromRecord?.status;
-
-      if (effectiveStatus === 'archived') {
-        try {
-          const headers = await getAuthHeaders();
-          const res = await fetch('/api/connections', {
-            method: 'PATCH',
-            headers: { ...headers, 'Content-Type': 'application/json' },
-            body: JSON.stringify({ action: 'restore', connectionId }),
-          });
-          if (!res.ok) {
-            const payload = await res.json().catch(() => ({}));
-            console.error('Server restore failed:', payload.error || res.statusText);
-            return false;
-          }
-          void loadConnections();
-          return true;
-        } catch (e) {
-          console.error('Unexpected server restore error:', e);
-          return false;
-        }
-      }
-
-      const supabase = getSupabaseClient();
-      if (!supabase || !user?.id || !archiveTableAvailable) return true;
       try {
-        const { error } = await supabase
-          .from('connection_archives')
-          .delete()
-          .eq('user_id', user.id)
-          .eq('connection_id', connectionId);
-
-        if (error) {
-          if (isMissingArchiveTableError(error)) {
-            setArchiveTableAvailable(false);
-            return true;
-          }
-          console.error('Error unarchiving connection:', error.message || error);
+        const headers = await getAuthHeaders();
+        const res = await fetch('/api/connections', {
+          method: 'PATCH',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'restore', connectionId }),
+        });
+        if (!res.ok) {
+          const payload = await res.json().catch(() => ({}));
+          console.error('Server restore failed:', payload.error || res.statusText);
+          updateJunctionArchivedIds((prev) => {
+            const next = new Set(prev);
+            next.add(connectionId);
+            return next;
+          });
           return false;
         }
+        void loadConnections();
         return true;
-      } catch (err) {
-        console.error('Unexpected unarchive error:', err);
+      } catch (e) {
+        console.error('Unexpected server restore error:', e);
+        updateJunctionArchivedIds((prev) => {
+          const next = new Set(prev);
+          next.add(connectionId);
+          return next;
+        });
         return false;
       }
     },
-    [
-      archiveTableAvailable,
-      connectionRecords,
-      getAuthHeaders,
-      isMissingArchiveTableError,
-      loadConnections,
-      updateArchivedIds,
-      user?.id,
-    ],
+    [getAuthHeaders, loadConnections, updateJunctionArchivedIds],
   );
 
   const openActionMenu = useCallback((connectionId: string) => {
@@ -1652,7 +1557,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
   const removeConnection = useCallback(async (connectionId: string): Promise<boolean> => {
     const prev = connectionRecords;
     setConnectionRecords((records) => records.filter((record) => record.id !== connectionId));
-    updateArchivedIds((ids) => {
+    updateJunctionArchivedIds((ids) => {
       const next = new Set(ids);
       next.delete(connectionId);
       return next;
@@ -1676,9 +1581,10 @@ export default function DashboardView({ user }: DashboardViewProps) {
     } catch (err) {
       console.error('Error removing connection:', err);
       setConnectionRecords(prev);
+      void loadConnections();
       return false;
     }
-  }, [connectionRecords, getAuthHeaders, selectedConnection?.id, updateArchivedIds]);
+  }, [connectionRecords, getAuthHeaders, loadConnections, selectedConnection?.id, updateJunctionArchivedIds]);
 
   const reportConnection = useCallback(async (connectionId: string, reason: string): Promise<boolean> => {
     const trimmedReason = reason.trim();
@@ -1798,27 +1704,23 @@ export default function DashboardView({ user }: DashboardViewProps) {
 
   const activeConnections = useMemo(
     () =>
-      chatCandidates.filter(
-        (c) => !archivedConnectionIds.has(c.id) && c.status !== 'archived',
-      ),
-    [archivedConnectionIds, chatCandidates],
+      chatCandidates.filter((c) => {
+        if (junctionArchivedConnectionIds.has(c.id)) return false;
+        if (c.status === 'archived') return false;
+        return isActiveChatListStatus(c.status);
+      }),
+    [chatCandidates, junctionArchivedConnectionIds],
   );
 
   const archivedConnections = useMemo(() => {
-    const serverArchived = chatCandidates.filter((c) => c.status === 'archived');
-    const userArchivedOnly = chatCandidates.filter(
-      (c) => archivedConnectionIds.has(c.id) && c.status !== 'archived',
-    );
-    const byId = new Map<string, (typeof chatCandidates)[number]>();
-    for (const c of [...serverArchived, ...userArchivedOnly]) {
-      if (!byId.has(c.id)) byId.set(c.id, c);
-    }
-    return Array.from(byId.values()).sort((a, b) => {
-      const left = a.chatLastMessageAt ?? a.chatUpdatedAt ?? a.dateMet.getTime();
-      const right = b.chatLastMessageAt ?? b.chatUpdatedAt ?? b.dateMet.getTime();
-      return right - left;
-    });
-  }, [archivedConnectionIds, chatCandidates]);
+    return chatCandidates
+      .filter((c) => junctionArchivedConnectionIds.has(c.id) || c.status === 'archived')
+      .sort((a, b) => {
+        const left = a.chatLastMessageAt ?? a.chatUpdatedAt ?? a.dateMet.getTime();
+        const right = b.chatLastMessageAt ?? b.chatUpdatedAt ?? b.dateMet.getTime();
+        return right - left;
+      });
+  }, [chatCandidates, junctionArchivedConnectionIds]);
 
   const dashboardMetrics = useMemo(
     () => buildDashboardMetrics(connectionRecords),
@@ -1902,6 +1804,8 @@ export default function DashboardView({ user }: DashboardViewProps) {
               <p className="text-sm text-zinc-500">Your digital memory box</p>
             </div>
           </motion.div>
+
+          <CurrentAvailabilitySection getAuthHeaders={getAuthHeaders} />
         </div>
 
         {/* Tabs */}
@@ -2068,7 +1972,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
                         currentUserId={user.id}
                         otherUserName={selectedConnection.name}
                         isArchived={
-                          archivedConnectionIds.has(selectedConnection.id) ||
+                          junctionArchivedConnectionIds.has(selectedConnection.id) ||
                           selectedConnection.status === 'archived'
                         }
                         isBlocked={selectedConnection.otherUserId ? blockedUserIds.has(selectedConnection.otherUserId) : false}
@@ -2170,15 +2074,15 @@ export default function DashboardView({ user }: DashboardViewProps) {
                             <p className="text-zinc-400">
                               {chatListTab === 'active'
                                 ? 'Start meeting people and your chats will appear here!'
-                                : 'Auto-archived chats and conversations you hid appear here. Tap Restore to move them back to Active.'}
+                                : 'Chats you archived and legacy auto-archived threads appear here. Tap Restore to move them back to Active.'}
                             </p>
                           </div>
                         ) : (
                           <div className="glass overflow-visible rounded-3xl border border-zinc-800 divide-y divide-zinc-800/50">
                             {visibleChatConnections.map((conn, index) => {
-                              const isUserArchived = archivedConnectionIds.has(conn.id);
-                              const isServerArchived = conn.status === 'archived';
-                              const isArchived = isUserArchived || isServerArchived;
+                              const isJunctionArchived = junctionArchivedConnectionIds.has(conn.id);
+                              const isLegacyServerArchived = conn.status === 'archived';
+                              const isArchived = isJunctionArchived || isLegacyServerArchived;
                               const previewText = conn.chatPreview?.trim() || 'No messages yet';
                               const activityLabel = formatChatActivity(conn.chatLastMessageAt ?? conn.chatUpdatedAt);
                               const archiveRow = connectionRecordToArchiveRow(conn);
@@ -2248,7 +2152,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
                                       <p className="mt-1 truncate pr-2 text-xs text-zinc-400">
                                         {conn.location} · {conn.dateMet.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                                       </p>
-                                      {archiveWarning && !isServerArchived && !isUserArchived ? (
+                                      {archiveWarning && !isLegacyServerArchived && !isJunctionArchived ? (
                                         <p
                                           className={`mt-1.5 flex items-center gap-1 truncate pr-2 text-[11px] ${
                                             archiveInfo?.isUrgent ? 'text-amber-300' : 'text-zinc-500'
@@ -2269,7 +2173,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
                                         <div className="flex flex-wrap items-center justify-end gap-2">
                                           {isArchived ? (
                                             <span className="shrink-0 rounded-full border border-zinc-600/40 bg-zinc-700/30 px-2 py-0.5 text-[10px] text-zinc-300">
-                                              {isServerArchived ? 'Auto-archived' : 'Archived'}
+                                              {isLegacyServerArchived ? 'Auto-archived' : 'Archived'}
                                             </span>
                                           ) : null}
                                         </div>
@@ -2312,7 +2216,7 @@ export default function DashboardView({ user }: DashboardViewProps) {
                                           }
                                           className="w-full text-left px-3 py-2 text-sm text-[#7cc3ff] hover:bg-zinc-800"
                                         >
-                                          {isServerArchived ? 'Restore' : 'Unarchive'}
+                                          {isLegacyServerArchived ? 'Restore' : 'Unarchive'}
                                         </button>
                                       ) : (
                                         <button

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -7,6 +7,10 @@ import {
   buildProfileConnectionLines,
   type SharedConnectionPayload,
 } from '@/lib/userProfile/formatSharedConnection';
+import {
+  AVAILABILITY_INTENT_BUBBLE_CLASS,
+  humanizeAvailabilityTimeframe,
+} from '@/lib/userProfile/availabilityIntentDisplay';
 
 export type AvailabilityIntentRow = {
   id: string;
@@ -35,20 +39,14 @@ export type UserProfilePayload = {
   } | null;
   /** Non-expired rows from `availability_intents` (when API can read them). */
   availabilityIntents?: AvailabilityIntentRow[];
+  last_intent_update_at?: string | null;
+  intent_sweep_expired?: boolean;
   /** Logged-in viewer’s tags (for client-side use; API also sends `sharedInterestTags`). */
   viewerInterestTags?: string[];
   sharedInterestTags?: string[];
   /** Mutual `connections` row for viewer + profile user. */
   sharedConnection?: SharedConnectionPayload | null;
 };
-
-function humanizeTimeframe(value: string): string {
-  const s = value.trim();
-  if (!s) return '';
-  return s
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-}
 
 function displayName(u: UserProfilePayload['user']): string {
   const fn = u.first_name?.trim();
@@ -306,88 +304,18 @@ export default function UserProfileModal({ userId, getAuthHeaders, onClose }: Us
 
                   <section>
                     <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">
-                      Availability
+                      Shared interests
                     </h3>
-                    {(() => {
-                      const intents = data.availabilityIntents ?? [];
-                      const hasLegacySchedule =
-                        !!data.availability &&
-                        (!!data.availability.available_days?.length ||
-                          !!data.availability.preferred_activities?.length ||
-                          !!data.availability.custom_status);
-
-                      if (intents.length === 0 && !hasLegacySchedule) {
-                        return (
-                          <p className="text-sm text-zinc-500">No availability shared yet</p>
-                        );
-                      }
-
-                      return (
-                        <div className="space-y-4 text-sm text-zinc-300">
-                          {intents.length > 0 ? (
-                            <div>
-                              <p className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500 mb-2">
-                                Open to
-                              </p>
-                              <ul className="flex flex-col gap-2">
-                                {intents.map((row) => (
-                                  <li
-                                    key={row.id}
-                                    className="flex flex-wrap items-center gap-2 rounded-xl border border-zinc-800/90 bg-zinc-900/40 px-3 py-2"
-                                  >
-                                    <span className="rounded-full border border-[#3A86FF]/35 bg-[#3A86FF]/10 px-2.5 py-0.5 text-xs text-sky-200">
-                                      {row.intent_tag.trim()}
-                                    </span>
-                                    <span className="text-xs text-zinc-500">
-                                      {humanizeTimeframe(row.timeframe)}
-                                    </span>
-                                  </li>
-                                ))}
-                              </ul>
-                            </div>
-                          ) : null}
-
-                          {hasLegacySchedule && data.availability ? (
-                            <div>
-                              <p className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500 mb-2">
-                                Schedule
-                              </p>
-                              <div className="space-y-2">
-                                {!!data.availability.available_days?.length && (
-                                  <p className="text-zinc-400">
-                                    <span className="text-zinc-500">Days: </span>
-                                    {data.availability.available_days
-                                      .map((d) => d.charAt(0).toUpperCase() + d.slice(1))
-                                      .join(', ')}
-                                  </p>
-                                )}
-                                {!!data.availability.preferred_activities?.length && (
-                                  <p className="text-zinc-400">
-                                    <span className="text-zinc-500">Activities: </span>
-                                    {data.availability.preferred_activities.join(', ')}
-                                  </p>
-                                )}
-                                {data.availability.custom_status && (
-                                  <p className="text-zinc-200 border-l-2 border-[#8338EC]/50 pl-3">
-                                    {data.availability.custom_status}
-                                  </p>
-                                )}
-                              </div>
-                            </div>
-                          ) : null}
-                        </div>
-                      );
-                    })()}
-                  </section>
-
-                  {!!data.sharedInterestTags?.length && (
-                    <section>
-                      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">
-                        Shared interests
-                      </h3>
-                      <p className="text-[11px] text-zinc-500 mb-2">
-                        Conversation starters you both listed
+                    <p className="text-[11px] text-zinc-500 mb-2">
+                      Compared with your interest tags — conversation starters you both listed
+                    </p>
+                    {data.sharedInterestTags === undefined ? (
+                      <p className="text-sm text-zinc-500">
+                        Open someone you have connected with to see overlap with your interests.
                       </p>
+                    ) : data.sharedInterestTags.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No shared tags yet</p>
+                    ) : (
                       <div className="flex flex-wrap gap-2">
                         {data.sharedInterestTags.map((t) => (
                           <span
@@ -398,8 +326,35 @@ export default function UserProfileModal({ userId, getAuthHeaders, onClose }: Us
                           </span>
                         ))}
                       </div>
-                    </section>
-                  )}
+                    )}
+                  </section>
+
+                  <section>
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-500 mb-2">
+                      Availability intents
+                    </h3>
+                    {data.intent_sweep_expired ? (
+                      <p className="text-sm text-amber-200/90">
+                        Availability is being refreshed — nothing active to show right now.
+                      </p>
+                    ) : (data.availabilityIntents ?? []).length === 0 ? (
+                      <p className="text-sm text-zinc-500">No availability intents shared yet</p>
+                    ) : (
+                      <div className="flex flex-wrap gap-2">
+                        {(data.availabilityIntents ?? []).map((row) => (
+                          <span
+                            key={row.id}
+                            className={`inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-0.5 ${AVAILABILITY_INTENT_BUBBLE_CLASS}`}
+                          >
+                            <span className="font-medium">{row.intent_tag.trim()}</span>
+                            <span className="text-[10px] text-sky-200/75">
+                              {humanizeAvailabilityTimeframe(row.timeframe)}
+                            </span>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </section>
                 </motion.div>
               )}
             </div>

--- a/components/chat/ChatView.tsx
+++ b/components/chat/ChatView.tsx
@@ -35,6 +35,12 @@ import type { ConnectionRecord } from '@/components/dashboard/ConnectionTable';
 import { deriveKeysForConnection, encryptContent, decryptContent, isEncrypted, type DerivedKeys } from '@/lib/chat/crypto';
 import { useAuth } from '@/lib/AuthContext';
 import { replySnippetForSend } from '@/lib/chat/reply';
+import {
+  AVAILABILITY_INTENT_BUBBLE_CLASS,
+  INTEREST_TAG_BUBBLE_CLASS,
+  SHARED_INTEREST_BUBBLE_CLASS,
+  humanizeAvailabilityTimeframe,
+} from '@/lib/userProfile/availabilityIntentDisplay';
 
 interface ChatViewProps {
   connection: ConnectionRecord;
@@ -178,7 +184,12 @@ export default function ChatView({
   const [mediaBusy, setMediaBusy] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [recordingMs, setRecordingMs] = useState(0);
+  const [peerInterestTags, setPeerInterestTags] = useState<string[]>([]);
   const [sharedInterestTags, setSharedInterestTags] = useState<string[]>([]);
+  const [peerAvailabilityIntents, setPeerAvailabilityIntents] = useState<
+    { id: string; timeframe: string; intent_tag: string; expires_at: string }[]
+  >([]);
+  const [peerIntentSweepExpired, setPeerIntentSweepExpired] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -315,7 +326,10 @@ export default function ChatView({
 
   useEffect(() => {
     if (!peerUserId) {
+      setPeerInterestTags([]);
       setSharedInterestTags([]);
+      setPeerAvailabilityIntents([]);
+      setPeerIntentSweepExpired(false);
       return;
     }
     let cancelled = false;
@@ -327,16 +341,45 @@ export default function ChatView({
           { headers },
         );
         const json = (await res.json().catch(() => ({}))) as {
+          tags?: unknown;
           sharedInterestTags?: unknown;
+          availabilityIntents?: unknown;
+          intent_sweep_expired?: unknown;
         };
         if (!res.ok || cancelled) return;
-        const raw = json.sharedInterestTags;
-        const tags = Array.isArray(raw)
-          ? raw.filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+        const rawPeer = json.tags;
+        const peerTags = Array.isArray(rawPeer)
+          ? rawPeer.filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
           : [];
-        if (!cancelled) setSharedInterestTags(tags);
+        const rawShared = json.sharedInterestTags;
+        const shared = Array.isArray(rawShared)
+          ? rawShared.filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+          : [];
+        const rawIntents = json.availabilityIntents;
+        const intents = Array.isArray(rawIntents)
+          ? rawIntents.filter(
+              (r): r is { id: string; timeframe: string; intent_tag: string; expires_at: string } =>
+                !!r &&
+                typeof r === 'object' &&
+                typeof (r as { id?: string }).id === 'string' &&
+                typeof (r as { timeframe?: string }).timeframe === 'string' &&
+                typeof (r as { intent_tag?: string }).intent_tag === 'string' &&
+                typeof (r as { expires_at?: string }).expires_at === 'string',
+            )
+          : [];
+        if (!cancelled) {
+          setPeerInterestTags(peerTags);
+          setSharedInterestTags(shared);
+          setPeerAvailabilityIntents(intents);
+          setPeerIntentSweepExpired(json.intent_sweep_expired === true);
+        }
       } catch {
-        if (!cancelled) setSharedInterestTags([]);
+        if (!cancelled) {
+          setPeerInterestTags([]);
+          setSharedInterestTags([]);
+          setPeerAvailabilityIntents([]);
+          setPeerIntentSweepExpired(false);
+        }
       }
     })();
     return () => {
@@ -1215,27 +1258,70 @@ export default function ChatView({
         </div>
       </div>
 
-      {sharedInterestTags.length > 0 && (
-        <div className="glass mb-3 shrink-0 rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-3">
+      <div className="mb-3 shrink-0 space-y-3">
+        <div className="glass rounded-2xl border border-zinc-800/90 bg-zinc-900/35 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Interests</p>
+          {peerInterestTags.length === 0 ? (
+            <p className="mt-1 text-[11px] text-zinc-500">They have not shared interests yet</p>
+          ) : (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {peerInterestTags.map((t) => (
+                <span key={t} className={INTEREST_TAG_BUBBLE_CLASS}>
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="glass rounded-2xl border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-3">
           <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-200/90">
             <Sparkles className="h-3.5 w-3.5 shrink-0" aria-hidden />
-            Conversation starters
+            Shared interests
           </div>
           <p className="mt-1 text-[11px] text-zinc-500">
-            Shared interests — try weaving one into your next message
+            Compared with your tags — conversation starters you both listed
           </p>
-          <div className="mt-2 flex flex-wrap gap-1.5">
-            {sharedInterestTags.map((t) => (
-              <span
-                key={t}
-                className="rounded-full border border-emerald-500/35 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] text-emerald-100"
-              >
-                {t}
-              </span>
-            ))}
-          </div>
+          {sharedInterestTags.length === 0 ? (
+            <p className="mt-2 text-[11px] text-zinc-500">No overlap yet</p>
+          ) : (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {sharedInterestTags.map((t) => (
+                <span key={t} className={SHARED_INTEREST_BUBBLE_CLASS}>
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+
+        <div className="glass rounded-2xl border border-[#3A86FF]/15 bg-[#3A86FF]/[0.05] px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-sky-200/85">
+            Availability intents
+          </p>
+          {peerIntentSweepExpired ? (
+            <p className="mt-1 text-[11px] text-amber-200/90">
+              Their availability is being refreshed — nothing active to show.
+            </p>
+          ) : peerAvailabilityIntents.length === 0 ? (
+            <p className="mt-1 text-[11px] text-zinc-500">No intents shared yet</p>
+          ) : (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {peerAvailabilityIntents.map((row) => (
+                <span
+                  key={row.id}
+                  className={`inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-0.5 ${AVAILABILITY_INTENT_BUBBLE_CLASS}`}
+                >
+                  <span className="font-medium">{row.intent_tag.trim()}</span>
+                  <span className="text-[10px] text-sky-200/75">
+                    {humanizeAvailabilityTimeframe(row.timeframe)}
+                  </span>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
 
       {/* ── Messages area ── */}
       <div

--- a/components/dashboard/CurrentAvailabilitySection.tsx
+++ b/components/dashboard/CurrentAvailabilitySection.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CalendarClock, Loader2, Pencil, X } from 'lucide-react';
+import {
+  AVAILABILITY_INTENT_BUBBLE_CLASS,
+  humanizeAvailabilityTimeframe,
+  isIntentSweepExpired,
+} from '@/lib/userProfile/availabilityIntentDisplay';
+
+export type AvailabilityIntentClientRow = {
+  id: string;
+  timeframe: string;
+  intent_tag: string;
+  expires_at: string;
+};
+
+const PRESET_INTENT_TAGS = [
+  'Coffee',
+  'Lunch',
+  'Walk',
+  'Drinks',
+  'Study',
+  'Gym',
+  'Networking',
+  'Games',
+] as const;
+
+function buildRolling24hPayload(tag: string): { timeframe: string; intent_tag: string; expires_at: string } {
+  const start = new Date();
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  const timeframe = `${start.toISOString()}/${end.toISOString()}`;
+  return {
+    timeframe,
+    intent_tag: tag.trim().slice(0, 25),
+    expires_at: end.toISOString(),
+  };
+}
+
+type CurrentAvailabilitySectionProps = {
+  getAuthHeaders: () => Promise<HeadersInit>;
+};
+
+export default function CurrentAvailabilitySection({ getAuthHeaders }: CurrentAvailabilitySectionProps) {
+  const [intents, setIntents] = useState<AvailabilityIntentClientRow[]>([]);
+  const [lastIntentUpdateAt, setLastIntentUpdateAt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [draftTags, setDraftTags] = useState<Set<string>>(new Set());
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  const sweepExpired = useMemo(
+    () => isIntentSweepExpired(lastIntentUpdateAt),
+    [lastIntentUpdateAt],
+  );
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const res = await fetch('/api/me/availability-intents', { headers });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || res.statusText);
+      setLastIntentUpdateAt(
+        typeof json.last_intent_update_at === 'string' ? json.last_intent_update_at : null,
+      );
+      const raw = json.intents;
+      const rows: AvailabilityIntentClientRow[] = Array.isArray(raw)
+        ? raw
+            .filter(
+              (r: unknown): r is AvailabilityIntentClientRow =>
+                !!r &&
+                typeof r === 'object' &&
+                typeof (r as AvailabilityIntentClientRow).id === 'string' &&
+                typeof (r as AvailabilityIntentClientRow).intent_tag === 'string',
+            )
+            .map((r: AvailabilityIntentClientRow) => ({
+              id: r.id,
+              timeframe: r.timeframe,
+              intent_tag: r.intent_tag,
+              expires_at: r.expires_at,
+            }))
+        : [];
+      setIntents(rows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load availability');
+      setIntents([]);
+      setLastIntentUpdateAt(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [getAuthHeaders]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (ev: MouseEvent) => {
+      const t = ev.target as Node | null;
+      if (t && popoverRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const openEditor = useCallback(() => {
+    setDraftTags(new Set(intents.map((i) => i.intent_tag.trim()).filter(Boolean)));
+    setOpen(true);
+    setError(null);
+  }, [intents]);
+
+  const toggleDraft = useCallback((tag: string) => {
+    setDraftTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) next.delete(tag);
+      else next.add(tag);
+      return next;
+    });
+  }, []);
+
+  const saveDraft = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const payload = {
+        intents: Array.from(draftTags).map((t) => buildRolling24hPayload(t)),
+      };
+      const res = await fetch('/api/me/availability-intents', {
+        method: 'PATCH',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json.error || res.statusText);
+      setLastIntentUpdateAt(
+        typeof json.last_intent_update_at === 'string' ? json.last_intent_update_at : new Date().toISOString(),
+      );
+      const raw = json.intents;
+      const rows: AvailabilityIntentClientRow[] = Array.isArray(raw)
+        ? raw
+            .filter(
+              (r: unknown): r is AvailabilityIntentClientRow =>
+                !!r &&
+                typeof r === 'object' &&
+                typeof (r as AvailabilityIntentClientRow).id === 'string' &&
+                typeof (r as AvailabilityIntentClientRow).intent_tag === 'string',
+            )
+            .map((r: AvailabilityIntentClientRow) => ({
+              id: r.id,
+              timeframe: r.timeframe,
+              intent_tag: r.intent_tag,
+              expires_at: r.expires_at,
+            }))
+        : [];
+      setIntents(rows);
+      setOpen(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }, [draftTags, getAuthHeaders]);
+
+  const displayIntents = sweepExpired ? [] : intents;
+
+  return (
+    <section className="relative mb-6 rounded-3xl border border-zinc-800/90 bg-zinc-900/40 px-5 py-4 backdrop-blur-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-white flex items-center gap-2">
+            <CalendarClock className="h-4 w-4 text-[#3A86FF]" aria-hidden />
+            Current availability
+          </h2>
+          <p className="mt-0.5 text-xs text-zinc-500">
+            What you are open to in the next 24 hours — visible to your connections
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => (open ? setOpen(false) : openEditor())}
+          className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700/80 bg-zinc-950/60 px-3 py-1.5 text-xs font-medium text-zinc-200 hover:border-[#8338EC]/40 hover:text-white transition-colors"
+        >
+          {displayIntents.length === 0 ? (
+            <>Set availability</>
+          ) : (
+            <>
+              <Pencil className="h-3.5 w-3.5" aria-hidden />
+              Edit
+            </>
+          )}
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="mt-4 flex items-center gap-2 text-xs text-zinc-500">
+          <Loader2 className="h-4 w-4 animate-spin text-[#8338EC]" aria-hidden />
+          Loading…
+        </div>
+      ) : error && !open ? (
+        <p className="mt-3 text-xs text-red-400">{error}</p>
+      ) : sweepExpired && displayIntents.length === 0 ? (
+        <p className="mt-3 text-sm text-amber-200/90">
+          Your previous availability expired (24h refresh). Set what you are open to now.
+        </p>
+      ) : displayIntents.length === 0 ? (
+        <p className="mt-3 text-sm text-zinc-500">
+          Nothing set — tap <span className="text-zinc-400">Set availability</span> to share what you are up for.
+        </p>
+      ) : (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {displayIntents.map((row) => (
+            <button
+              key={row.id}
+              type="button"
+              onClick={openEditor}
+              className={`${AVAILABILITY_INTENT_BUBBLE_CLASS} cursor-pointer transition-opacity hover:opacity-90 text-left`}
+            >
+              <span className="font-medium">{row.intent_tag.trim()}</span>
+              <span className="ml-2 text-[10px] text-sky-200/70">
+                {humanizeAvailabilityTimeframe(row.timeframe)}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            ref={popoverRef}
+            initial={{ opacity: 0, y: -6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={{ duration: 0.18 }}
+            className="absolute left-4 right-4 top-full z-30 mt-2 rounded-2xl border border-zinc-700/90 bg-zinc-950 p-4 shadow-2xl"
+          >
+            <div className="flex items-center justify-between gap-2 mb-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                Open to (next 24h)
+              </p>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-lg p-1 text-zinc-500 hover:bg-zinc-800 hover:text-white"
+                aria-label="Close"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {PRESET_INTENT_TAGS.map((tag) => {
+                const on = draftTags.has(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggleDraft(tag)}
+                    className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                      on
+                        ? 'border-[#3A86FF]/50 bg-[#3A86FF]/20 text-sky-100'
+                        : 'border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:border-zinc-600'
+                    }`}
+                  >
+                    {tag}
+                  </button>
+                );
+              })}
+            </div>
+            {error ? <p className="mt-2 text-xs text-red-400">{error}</p> : null}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-xl px-3 py-1.5 text-xs text-zinc-400 hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => void saveDraft()}
+                className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-[#8338EC] to-[#6520c0] px-4 py-1.5 text-xs font-semibold text-white disabled:opacity-60"
+              >
+                {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                Save
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  );
+}

--- a/database/migrations/20260408120000_connection_junctions_and_intent_timestamp.sql
+++ b/database/migrations/20260408120000_connection_junctions_and_intent_timestamp.sql
@@ -1,0 +1,67 @@
+-- Relational archive/hide for connections + profile intent refresh timestamp
+-- Idempotent where possible.
+-- Canonical mirror: supabase/migrations/20260408120000_connection_junctions_and_intent_timestamp.sql
+
+-- ─── connection_archives (per-user archive of a shared connection row) ─────
+
+CREATE TABLE IF NOT EXISTS public.connection_archives (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    connection_id uuid NOT NULL REFERENCES public.connections (id) ON DELETE CASCADE,
+    archived_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, connection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_archives_user_id
+    ON public.connection_archives (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_connection_archives_connection_id
+    ON public.connection_archives (connection_id);
+
+ALTER TABLE public.connection_archives ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "connection_archives_own_all" ON public.connection_archives;
+CREATE POLICY "connection_archives_own_all"
+    ON public.connection_archives
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.connection_archives TO authenticated;
+
+-- ─── connection_hidden (per-user soft delete / hide) ─────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.connection_hidden (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    connection_id uuid NOT NULL REFERENCES public.connections (id) ON DELETE CASCADE,
+    hidden_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, connection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_hidden_user_id
+    ON public.connection_hidden (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_connection_hidden_connection_id
+    ON public.connection_hidden (connection_id);
+
+ALTER TABLE public.connection_hidden ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "connection_hidden_own_all" ON public.connection_hidden;
+CREATE POLICY "connection_hidden_own_all"
+    ON public.connection_hidden
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.connection_hidden TO authenticated;
+
+-- ─── users.last_intent_update_at (for 24h expiration sweep) ──────────────────
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS last_intent_update_at timestamptz;
+
+COMMENT ON COLUMN public.users.last_intent_update_at IS
+    'UTC timestamp when availability intents were last saved; used for intent expiration policies.';

--- a/lib/userProfile/availabilityIntentDisplay.ts
+++ b/lib/userProfile/availabilityIntentDisplay.ts
@@ -1,0 +1,28 @@
+/** Shared formatting for availability intent UI (profile, chat, dashboard). */
+
+export function humanizeAvailabilityTimeframe(value: string): string {
+  const s = value.trim();
+  if (!s) return '';
+  return s
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Matches primary interest tag pills (UserProfileModal). */
+export const AVAILABILITY_INTENT_BUBBLE_CLASS =
+  'rounded-full border border-[#3A86FF]/35 bg-[#3A86FF]/10 px-3 py-1 text-xs text-sky-200';
+
+export const SHARED_INTEREST_BUBBLE_CLASS =
+  'rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs text-emerald-200';
+
+export const INTEREST_TAG_BUBBLE_CLASS =
+  'rounded-full border border-[#8338EC]/35 bg-[#8338EC]/10 px-3 py-1 text-xs text-[#c4b5fd]';
+
+const MS_24H = 24 * 60 * 60 * 1000;
+
+export function isIntentSweepExpired(lastIntentUpdateAtIso: string | null | undefined): boolean {
+  if (!lastIntentUpdateAtIso?.trim()) return false;
+  const t = Date.parse(lastIntentUpdateAtIso);
+  if (!Number.isFinite(t)) return false;
+  return Date.now() - t >= MS_24H;
+}

--- a/lib/userProfile/availabilityIntentDisplay.ts
+++ b/lib/userProfile/availabilityIntentDisplay.ts
@@ -1,8 +1,47 @@
 /** Shared formatting for availability intent UI (profile, chat, dashboard). */
 
+const MS_24H = 24 * 60 * 60 * 1000;
+const MS_24H_TOLERANCE = 2 * 60 * 60 * 1000;
+
+function humanizeIsoInterval(startMs: number, endMs: number): string {
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+    return '';
+  }
+  const duration = endMs - startMs;
+  if (Math.abs(duration - MS_24H) <= MS_24H_TOLERANCE) {
+    return 'Next 24h';
+  }
+  const endDate = new Date(endMs);
+  const nowY = new Date().getFullYear();
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    ...(endDate.getFullYear() !== nowY ? { year: 'numeric' as const } : {}),
+  }).format(endDate);
+}
+
+/**
+ * `timeframe` is either an ISO 8601 interval (`start/end`, UTC) or a legacy token
+ * such as `this_week`.
+ */
 export function humanizeAvailabilityTimeframe(value: string): string {
   const s = value.trim();
   if (!s) return '';
+
+  const slash = s.indexOf('/');
+  if (slash > 0 && slash < s.length - 1) {
+    const startRaw = s.slice(0, slash).trim();
+    const endRaw = s.slice(slash + 1).trim();
+    const startMs = Date.parse(startRaw);
+    const endMs = Date.parse(endRaw);
+    if (Number.isFinite(startMs) && Number.isFinite(endMs)) {
+      const label = humanizeIsoInterval(startMs, endMs);
+      if (label) {
+        return label === 'Next 24h' ? label : `Until ${label}`;
+      }
+    }
+  }
+
   return s
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
@@ -17,8 +56,6 @@ export const SHARED_INTEREST_BUBBLE_CLASS =
 
 export const INTEREST_TAG_BUBBLE_CLASS =
   'rounded-full border border-[#8338EC]/35 bg-[#8338EC]/10 px-3 py-1 text-xs text-[#c4b5fd]';
-
-const MS_24H = 24 * 60 * 60 * 1000;
 
 export function isIntentSweepExpired(lastIntentUpdateAtIso: string | null | undefined): boolean {
   if (!lastIntentUpdateAtIso?.trim()) return false;

--- a/supabase/migrations/20260408120000_connection_junctions_and_intent_timestamp.sql
+++ b/supabase/migrations/20260408120000_connection_junctions_and_intent_timestamp.sql
@@ -1,0 +1,66 @@
+-- Relational archive/hide for connections + profile intent refresh timestamp
+-- Idempotent where possible.
+
+-- ─── connection_archives (per-user archive of a shared connection row) ─────
+
+CREATE TABLE IF NOT EXISTS public.connection_archives (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    connection_id uuid NOT NULL REFERENCES public.connections (id) ON DELETE CASCADE,
+    archived_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, connection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_archives_user_id
+    ON public.connection_archives (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_connection_archives_connection_id
+    ON public.connection_archives (connection_id);
+
+ALTER TABLE public.connection_archives ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "connection_archives_own_all" ON public.connection_archives;
+CREATE POLICY "connection_archives_own_all"
+    ON public.connection_archives
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.connection_archives TO authenticated;
+
+-- ─── connection_hidden (per-user soft delete / hide) ─────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.connection_hidden (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    connection_id uuid NOT NULL REFERENCES public.connections (id) ON DELETE CASCADE,
+    hidden_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (user_id, connection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connection_hidden_user_id
+    ON public.connection_hidden (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_connection_hidden_connection_id
+    ON public.connection_hidden (connection_id);
+
+ALTER TABLE public.connection_hidden ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "connection_hidden_own_all" ON public.connection_hidden;
+CREATE POLICY "connection_hidden_own_all"
+    ON public.connection_hidden
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.connection_hidden TO authenticated;
+
+-- ─── users.last_intent_update_at (for 24h expiration sweep) ──────────────────
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS last_intent_update_at timestamptz;
+
+COMMENT ON COLUMN public.users.last_intent_update_at IS
+    'UTC timestamp when availability intents were last saved; used for intent expiration policies.';

--- a/types/database-connection-junctions.ts
+++ b/types/database-connection-junctions.ts
@@ -1,0 +1,17 @@
+/**
+ * Junction tables for per-user connection visibility (not `connections.status`).
+ */
+
+export type ConnectionArchiveRow = {
+  id: string;
+  user_id: string;
+  connection_id: string;
+  archived_at: string;
+};
+
+export type ConnectionHiddenRow = {
+  id: string;
+  user_id: string;
+  connection_id: string;
+  hidden_at: string;
+};

--- a/types/database-connections.ts
+++ b/types/database-connections.ts
@@ -1,6 +1,9 @@
 /**
  * Documented shapes for `public.connections` used by the web app and API.
  * Regenerate from Supabase CLI when the schema changes.
+ *
+ * Per-user archive/hide uses `connection_archives` and `connection_hidden`, not
+ * `status = 'archived' | 'removed'` on this table.
  */
 import type { ConnectionLifecycleStatus } from '@/types/connection';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change aligns the web dashboard with relational archiving and per-user hiding via `connection_archives` and `connection_hidden`, adds a prominent **Current availability** block with inline editing backed by new API routes, and standardizes profile/chat “icebreaker” ordering and bubble styling for interests, shared interests, and availability intents.

## Follow-up fixes (this revision)

- **POST /api/connections** duplicate check no longer skips rows the authenticated user has in `connection_hidden`, so a shared connection cannot be duplicated for the other party.
- **`humanizeAvailabilityTimeframe`** parses ISO `start/end` intervals (e.g. from `buildRolling24hPayload`) to **Next 24h** or **Until Apr 9** style labels; legacy underscore tokens unchanged.

## Connections API and dashboard

- `GET /api/connections` (default) returns only connections where the caller has **no** row in `connection_hidden` and **no** row in `connection_archives`, still scoped to active lifecycle rows via the existing status filter.
- `GET /api/connections?statusScope=archived` returns connections that **are** in `connection_archives` for the caller, excluding anything in `connection_hidden`.
- `DELETE /api/connections` inserts into `connection_hidden` (and clears an archive junction row if present) instead of setting `status = removed`.
- `PATCH` restore deletes the caller’s `connection_archives` row and, if the row still has legacy `status = archived`, promotes it to `active`.
- `DashboardView` loads lists through these endpoints (plus a direct Supabase read for legacy `status = archived` rows so older data still appears until migrated). Chat **Active** / **Archived** tabs use the junction archive set and legacy status for labels.

## Availability intents

- New `GET` and `PATCH` `/api/me/availability-intents`: replace non-expired intent rows and set `users.last_intent_update_at` to UTC `now()` on save.
- Profile API returns `last_intent_update_at`, `intent_sweep_expired`, and omits intent rows when the profile’s last intent update is older than 24h (graceful “expired” messaging in UI).
- **Current availability** section on the main dashboard (under the welcome header): preset-tag popover, bubbles match interest pill styling, expired state copy when the sweep window applies.

## Profile modal and chat

- **UserProfileModal**: strict vertical order — Interests → Shared interests → Availability intents (bubble layout, no legacy `user_availability` block).
- **ChatView**: same three sections above the thread with shared bubble classes.

## Database

- Migration adds `connection_archives`, `connection_hidden` (if missing), and `users.last_intent_update_at`.

## Testing

- `npm test`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40a8d5ca-f38d-41e2-80a0-8e60728d9a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40a8d5ca-f38d-41e2-80a0-8e60728d9a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lightningbolts/click-web/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
