### PR TITLE
fix(api): persist encounter sensor data and relative altitude

### DIFF
--- a/app/api/connections/[connectionId]/tags/route.ts
+++ b/app/api/connections/[connectionId]/tags/route.ts
@@ -1,0 +1,215 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  normalizeContextTag,
+  normalizeNoiseLevelCategory,
+  resolveContextTagId,
+} from '@/lib/server/connectionEncounterContextTag';
+import { getSupabaseFromRouteRequest } from '@/lib/server/supabaseRouteAuth';
+import { fetchTerrainElevationMeters } from '@/lib/server/terrainElevation';
+
+function createAdminClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function finiteNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function normalizeClientNoiseLevelString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeElevationCategoryString(value: unknown): string | null {
+  return normalizeClientNoiseLevelString(value);
+}
+
+function mergeContextTags(existing: string[] | null | undefined, nextId: string | null): string[] {
+  const base = Array.isArray(existing) ? [...existing] : [];
+  if (nextId == null || nextId.trim().length === 0) {
+    return base;
+  }
+  const trimmed = nextId.trim();
+  if (!base.includes(trimmed)) {
+    base.push(trimmed);
+  }
+  return base;
+}
+
+/**
+ * PATCH — merge context tags and optional encounter sensor fields on the latest
+ * `connection_encounters` row for a connection (post-crossing tag flow).
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ connectionId: string }> },
+) {
+  try {
+    const { user, authError: userError } = await getSupabaseFromRouteRequest(request);
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { connectionId } = await params;
+    if (!connectionId?.trim()) {
+      return NextResponse.json({ error: 'Missing connection id' }, { status: 400 });
+    }
+
+    const rawBody = await request.json().catch(() => null);
+    const body = isRecord(rawBody) ? rawBody : {};
+
+    const contextTag = body.contextTag ?? body.context_tag;
+    const contextTagObject = body.contextTagObject ?? body.context_tag_object;
+    const noiseLevelCategory = body.noiseLevelCategory ?? body.noise_level_category;
+    const heightCategoryRaw = body.height_category ?? body.heightCategory;
+    const elevationCategoryRaw = body.elevation_category ?? body.elevationCategory;
+    const exactNoiseLevelDb = body.exactNoiseLevelDb ?? body.exact_noise_level_db;
+    const exactBarometricElevationMeters =
+      body.exactBarometricElevationMeters ?? body.exact_barometric_elevation_m;
+    const clientNoiseLevelString = normalizeClientNoiseLevelString(
+      body.noise_level ?? body.noiseLevel,
+    );
+
+    const resolvedContextTag = normalizeContextTag(contextTagObject ?? contextTag);
+    const resolvedContextTagId = resolveContextTagId(resolvedContextTag);
+    const enumNoiseLevel = normalizeNoiseLevelCategory(noiseLevelCategory);
+    const resolvedNoiseForEncounter =
+      enumNoiseLevel ?? clientNoiseLevelString ?? normalizeNoiseLevelCategory(heightCategoryRaw);
+    const resolvedElevationCategory =
+      normalizeElevationCategoryString(elevationCategoryRaw) ??
+      normalizeElevationCategoryString(heightCategoryRaw);
+
+    if (
+      resolvedContextTagId == null &&
+      resolvedNoiseForEncounter == null &&
+      resolvedElevationCategory == null &&
+      finiteNumber(exactNoiseLevelDb) == null &&
+      finiteNumber(exactBarometricElevationMeters) == null
+    ) {
+      return NextResponse.json(
+        { error: 'Provide at least contextTag, noise_level, height_category, or barometric/noise fields' },
+        { status: 400 },
+      );
+    }
+
+    const adminClient = createAdminClient();
+    const trimmedConnId = connectionId.trim();
+
+    const { data: row, error: fetchError } = await adminClient
+      .from('connections')
+      .select('id, user_ids')
+      .eq('id', trimmedConnId)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error('connection tags lookup:', fetchError);
+      return NextResponse.json({ error: fetchError.message }, { status: 400 });
+    }
+
+    const ids = (row?.user_ids as string[] | null) ?? [];
+    if (!row || !ids.includes(user.id)) {
+      return NextResponse.json({ error: 'Connection not found' }, { status: 404 });
+    }
+
+    const { data: latestEnc, error: encLookupErr } = await adminClient
+      .from('connection_encounters')
+      .select(
+        'id, context_tags, gps_lat, gps_lon, noise_level, elevation_category, exact_noise_level_db, exact_barometric_elevation_m, relative_altitude_m',
+      )
+      .eq('connection_id', trimmedConnId)
+      .order('encountered_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (encLookupErr) {
+      console.error('connection tags encounter lookup:', encLookupErr);
+      return NextResponse.json({ error: encLookupErr.message }, { status: 400 });
+    }
+
+    if (!latestEnc?.id) {
+      return NextResponse.json({ error: 'No encounter row to update' }, { status: 404 });
+    }
+
+    const updatePayload: Record<string, unknown> = {};
+
+    const prevTags = (latestEnc as { context_tags?: string[] | null }).context_tags;
+    if (resolvedContextTagId != null) {
+      updatePayload.context_tags = mergeContextTags(prevTags, resolvedContextTagId);
+    }
+
+    if (resolvedNoiseForEncounter != null) {
+      updatePayload.noise_level = resolvedNoiseForEncounter;
+    }
+    if (resolvedElevationCategory != null) {
+      updatePayload.elevation_category = resolvedElevationCategory;
+    }
+
+    const encDb = finiteNumber(exactNoiseLevelDb);
+    if (encDb != null) {
+      updatePayload.exact_noise_level_db = encDb;
+    }
+
+    const encElev = finiteNumber(exactBarometricElevationMeters);
+    if (encElev != null) {
+      updatePayload.exact_barometric_elevation_m = encElev;
+    }
+
+    let lat = finiteNumber((latestEnc as { gps_lat?: unknown }).gps_lat);
+    let lon = finiteNumber((latestEnc as { gps_lon?: unknown }).gps_lon);
+    const coordsFromBodyLat = finiteNumber(body.lat ?? body.gps_lat);
+    const coordsFromBodyLon = finiteNumber(body.lon ?? body.gps_lon);
+    if (
+      coordsFromBodyLat != null &&
+      coordsFromBodyLon != null &&
+      !(coordsFromBodyLat === 0 && coordsFromBodyLon === 0)
+    ) {
+      lat = coordsFromBodyLat;
+      lon = coordsFromBodyLon;
+      updatePayload.gps_lat = lat;
+      updatePayload.gps_lon = lon;
+    }
+
+    if (encElev != null && lat != null && lon != null && !(lat === 0 && lon === 0)) {
+      try {
+        const terrainM = await fetchTerrainElevationMeters(lat, lon);
+        if (terrainM != null) {
+          updatePayload.relative_altitude_m = encElev - terrainM;
+        }
+      } catch (openElevErr) {
+        console.error('Open-Elevation lookup failed (non-fatal):', openElevErr);
+      }
+    }
+
+    if (Object.keys(updatePayload).length === 0) {
+      return NextResponse.json({ success: true, encounter: latestEnc });
+    }
+
+    const { data: updated, error: upErr } = await adminClient
+      .from('connection_encounters')
+      .update(updatePayload)
+      .eq('id', latestEnc.id)
+      .select()
+      .maybeSingle();
+
+    if (upErr) {
+      console.error('connection_encounters tags update:', upErr);
+      return NextResponse.json({ error: upErr.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true, encounter: updated });
+  } catch (e) {
+    console.error('connection tags PATCH:', e);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -3,6 +3,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { ConnectionLifecycleStatus } from '@/types/connection';
 import { ACTIVE_CONNECTIONS_DB_OR_FILTER } from '@/lib/dashboard/connectionStatus';
 import { getSupabaseFromRouteRequest } from '@/lib/server/supabaseRouteAuth';
+import { fetchTerrainElevationMeters } from '@/lib/server/terrainElevation';
+import {
+  normalizeContextTag,
+  normalizeNoiseLevelCategory,
+  resolveContextTagId,
+  type ContextTagPayload,
+} from '@/lib/server/connectionEncounterContextTag';
 
 /**
  * Connections API
@@ -30,6 +37,20 @@ const DISPLAY_LOCATION_FALLBACK = 'A new city';
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function finiteNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function normalizeClientNoiseLevelString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeElevationCategoryString(value: unknown): string | null {
+  return normalizeClientNoiseLevelString(value);
 }
 
 function firstNonEmptyString(values: unknown[]): string | null {
@@ -200,12 +221,6 @@ function computeProximityScore(params: {
   return { score, signals };
 }
 
-type ContextTagPayload = {
-  id: string;
-  label: string;
-  emoji: string;
-};
-
 type MemoryCapsulePayload = {
   connectionId: string;
   locationName: string | null;
@@ -223,49 +238,6 @@ type MemoryCapsulePayload = {
 
 function buildUtcTimeOfDayLabel(isoTimestamp: string): string {
   return `${isoTimestamp.slice(11, 19)} UTC`;
-}
-
-function normalizeContextTag(input: unknown): ContextTagPayload | null {
-  if (typeof input === 'string') {
-    const label = input.trim();
-    return label ? { id: 'custom', label, emoji: '✏️' } : null;
-  }
-
-  if (
-    input &&
-    typeof input === 'object' &&
-    'id' in input &&
-    'label' in input &&
-    typeof input.id === 'string' &&
-    typeof input.label === 'string'
-  ) {
-    const candidate = input as { id: string; label: string; emoji?: unknown };
-    return {
-      id: candidate.id,
-      label: candidate.label,
-      emoji: typeof candidate.emoji === 'string' ? candidate.emoji : '✏️',
-    };
-  }
-
-  return null;
-}
-
-function resolveContextTagId(contextTag: ContextTagPayload | null): string | null {
-  if (!contextTag) {
-    return null;
-  }
-
-  return contextTag.id === 'custom' ? contextTag.label : contextTag.id;
-}
-
-function normalizeNoiseLevel(value: unknown): MemoryCapsulePayload['noiseLevelCategory'] {
-  return value === 'VERY_QUIET' ||
-    value === 'QUIET' ||
-    value === 'MODERATE' ||
-    value === 'LOUD' ||
-    value === 'VERY_LOUD'
-    ? value
-    : null;
 }
 
 function toConditionLabel(weatherCode: number): string {
@@ -726,28 +698,39 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
+    const rawBody = await request.json();
+    const body = isRecord(rawBody) ? rawBody : {};
 
-    const {
-      userId1,
-      userId2,
-      location1,        // { lat, lon } — initiator's GPS
-      location2,        // { lat, lon } — scanner's GPS (if available)
-      connectionMethod = 'qr',
-      tokenAgeMs,       // milliseconds since token was created (null for NFC/legacy)
-      wifiBssid1,       // initiator's WiFi BSSID (optional)
-      wifiBssid2,       // scanner's WiFi BSSID (optional)
-      contextTag,       // user-defined tag (optional)
-      contextTagObject,
-      initiatorId,
-      responderId,
-      initiator_id,
-      responder_id,
-      location_name,
-      noiseLevelCategory,
-      exactNoiseLevelDb,
-      exactBarometricElevationMeters,
-    } = body;
+    const userId1 = typeof body.userId1 === 'string' ? body.userId1 : null;
+    const userId2 = typeof body.userId2 === 'string' ? body.userId2 : null;
+    const location1 = isRecord(body.location1) ? body.location1 : null;
+    const location2 = isRecord(body.location2) ? body.location2 : null;
+    const connectionMethod =
+      typeof body.connectionMethod === 'string' && body.connectionMethod.trim().length > 0
+        ? body.connectionMethod.trim()
+        : 'qr';
+    const tokenAgeMs = finiteNumber(body.tokenAgeMs);
+    const wifiBssid1 = typeof body.wifiBssid1 === 'string' ? body.wifiBssid1 : undefined;
+    const wifiBssid2 = typeof body.wifiBssid2 === 'string' ? body.wifiBssid2 : undefined;
+    const contextTag = body.contextTag;
+    const contextTagObject = body.contextTagObject;
+    const initiatorId = body.initiatorId;
+    const responderId = body.responderId;
+    const initiator_id = body.initiator_id;
+    const responder_id = body.responder_id;
+    const location_name = body.location_name;
+    const noiseLevelCategory = body.noiseLevelCategory ?? body.noise_level_category;
+    const heightCategoryRaw = body.height_category ?? body.heightCategory;
+    const elevationCategoryRaw = body.elevation_category ?? body.elevationCategory;
+    const exactNoiseLevelDb =
+      body.exactNoiseLevelDb ??
+      body.exact_noise_level_db;
+    const exactBarometricElevationMeters =
+      body.exactBarometricElevationMeters ??
+      body.exact_barometric_elevation_m;
+    const clientNoiseLevelString = normalizeClientNoiseLevelString(
+      body.noise_level ?? body.noiseLevel,
+    );
 
     // Validate required fields
     if (!userId1 || !userId2) {
@@ -763,19 +746,21 @@ export async function POST(request: NextRequest) {
 
     // ── Layer 2: GPS proximity validation ──
 
-    const loc1Valid = location1 && isFinite(location1.lat) && isFinite(location1.lon) &&
-      !(location1.lat === 0 && location1.lon === 0);
-    const loc2Valid = location2 && isFinite(location2.lat) && isFinite(location2.lon) &&
-      !(location2.lat === 0 && location2.lon === 0);
+    const loc1Lat = location1 ? finiteNumber(location1.lat) : null;
+    const loc1Lon = location1 ? finiteNumber(location1.lon) : null;
+    const loc2Lat = location2 ? finiteNumber(location2.lat) : null;
+    const loc2Lon = location2 ? finiteNumber(location2.lon) : null;
+
+    const loc1Valid =
+      loc1Lat != null && loc1Lon != null && !(loc1Lat === 0 && loc1Lon === 0);
+    const loc2Valid =
+      loc2Lat != null && loc2Lon != null && !(loc2Lat === 0 && loc2Lon === 0);
 
     let gpsDistanceMeters: number | null = null;
     const gpsAvailable = loc1Valid || loc2Valid;
 
     if (loc1Valid && loc2Valid) {
-      gpsDistanceMeters = haversineMeters(
-        location1.lat, location1.lon,
-        location2.lat, location2.lon
-      );
+      gpsDistanceMeters = haversineMeters(loc1Lat, loc1Lon, loc2Lat, loc2Lon);
 
       // Hard reject if distance > 150m
       if (gpsDistanceMeters > 150) {
@@ -828,11 +813,11 @@ export async function POST(request: NextRequest) {
     // If both are available, prefer initiator location1.
     let geoLocation: { lat: number; lon: number };
     if (loc1Valid && loc2Valid) {
-      geoLocation = { lat: location1.lat, lon: location1.lon };
+      geoLocation = { lat: loc1Lat, lon: loc1Lon };
     } else if (loc1Valid) {
-      geoLocation = { lat: location1.lat, lon: location1.lon };
-    } else if (loc2Valid) {
-      geoLocation = { lat: location2.lat, lon: location2.lon };
+      geoLocation = { lat: loc1Lat, lon: loc1Lon };
+    } else if (loc2Valid && loc2Lat != null && loc2Lon != null) {
+      geoLocation = { lat: loc2Lat, lon: loc2Lon };
     } else {
       // No GPS available — use a null-island sentinel that the frontend filters out
       geoLocation = { lat: 0, lon: 0 };
@@ -844,7 +829,12 @@ export async function POST(request: NextRequest) {
     const expiry = now + 30 * 24 * 60 * 60 * 1000; // 30 days
     const resolvedContextTag = normalizeContextTag(contextTagObject ?? contextTag);
     const resolvedContextTagId = resolveContextTagId(resolvedContextTag);
-    const resolvedNoiseLevel = normalizeNoiseLevel(noiseLevelCategory);
+    const enumNoiseLevel = normalizeNoiseLevelCategory(noiseLevelCategory);
+    const resolvedNoiseForEncounter =
+      enumNoiseLevel ?? clientNoiseLevelString ?? normalizeNoiseLevelCategory(heightCategoryRaw);
+    const resolvedElevationCategory =
+      normalizeElevationCategoryString(elevationCategoryRaw) ??
+      normalizeElevationCategoryString(heightCategoryRaw);
     const resolvedInitiatorId = initiator_id ?? initiatorId ?? (connectionMethod === 'qr' ? userId2 : userId1);
     const resolvedResponderId = responder_id ?? responderId ?? (connectionMethod === 'qr' ? userId1 : userId2);
 
@@ -855,7 +845,7 @@ export async function POST(request: NextRequest) {
       weatherSnapshot: null,
       contextTag: resolvedContextTag,
       photoUri: null,
-      noiseLevelCategory: resolvedNoiseLevel,
+      noiseLevelCategory: enumNoiseLevel,
     };
 
     const userIdsForRow = existing?.user_ids ?? [userId1, userId2];
@@ -992,9 +982,14 @@ export async function POST(request: NextRequest) {
       encountered_at: new Date(now).toISOString(),
       display_location: displayLocation,
       context_tags: resolvedContextTagId ? [resolvedContextTagId] : [],
-      noise_level: resolvedNoiseLevel,
       weather_snapshot: memoryCapsule.weatherSnapshot,
     };
+    if (resolvedNoiseForEncounter != null) {
+      encounterInsert.noise_level = resolvedNoiseForEncounter;
+    }
+    if (resolvedElevationCategory != null) {
+      encounterInsert.elevation_category = resolvedElevationCategory;
+    }
     const resolvedLocationName = manualLocationName ?? specificLocationName ?? memoryCapsule.locationName;
     if (resolvedLocationName) {
       encounterInsert.location_name = resolvedLocationName;
@@ -1009,16 +1004,34 @@ export async function POST(request: NextRequest) {
     }
     if (semanticLocation != null) encounterInsert.semantic_location = semanticLocation;
 
-    const encDb =
-      typeof exactNoiseLevelDb === 'number' && Number.isFinite(exactNoiseLevelDb)
-        ? exactNoiseLevelDb
-        : null;
-    const encElev =
-      typeof exactBarometricElevationMeters === 'number' && Number.isFinite(exactBarometricElevationMeters)
-        ? exactBarometricElevationMeters
-        : null;
-    if (encDb != null) encounterInsert.exact_noise_level_db = encDb;
-    if (encElev != null) encounterInsert.exact_barometric_elevation_m = encElev;
+    const encDb = finiteNumber(exactNoiseLevelDb);
+    const encElev = finiteNumber(exactBarometricElevationMeters);
+    if (encDb != null) {
+      encounterInsert.exact_noise_level_db = encDb;
+    }
+    if (encElev != null) {
+      encounterInsert.exact_barometric_elevation_m = encElev;
+    }
+
+    let relativeAltitudeM: number | null = null;
+    if (
+      encElev != null &&
+      Number.isFinite(geoLocation.lat) &&
+      Number.isFinite(geoLocation.lon) &&
+      !(geoLocation.lat === 0 && geoLocation.lon === 0)
+    ) {
+      try {
+        const terrainM = await fetchTerrainElevationMeters(geoLocation.lat, geoLocation.lon);
+        if (terrainM != null) {
+          relativeAltitudeM = encElev - terrainM;
+        }
+      } catch (openElevErr) {
+        console.error('Open-Elevation lookup failed (non-fatal):', openElevErr);
+      }
+    }
+    if (relativeAltitudeM != null) {
+      encounterInsert.relative_altitude_m = relativeAltitudeM;
+    }
 
     const { error: encounterErr } = await adminClient.from('connection_encounters').insert(encounterInsert);
     let encounter_logged = true;

--- a/app/api/qr/route.ts
+++ b/app/api/qr/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
 import { displayNameFromUserMetadata } from '@/lib/userDisplayName';
 import { getAuthenticatedSupabase } from '@/lib/server/supabaseAuth';
+import { fetchTerrainElevationMeters } from '@/lib/server/terrainElevation';
 
 /**
  * QR Code Connection API — Proximity Verification Layer 1
@@ -43,6 +44,28 @@ const DISPLAY_LOCATION_FALLBACK = 'A new city';
 
 function finiteNumber(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function normalizeClientNoiseLevelString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeNoiseLevelCategory(
+  value: unknown,
+): 'VERY_QUIET' | 'QUIET' | 'MODERATE' | 'LOUD' | 'VERY_LOUD' | null {
+  return value === 'VERY_QUIET' ||
+    value === 'QUIET' ||
+    value === 'MODERATE' ||
+    value === 'LOUD' ||
+    value === 'VERY_LOUD'
+    ? value
+    : null;
+}
+
+function normalizeElevationCategoryString(value: unknown): string | null {
+  return normalizeClientNoiseLevelString(value);
 }
 
 function finiteBatteryPct(v: unknown): number | null {
@@ -399,6 +422,22 @@ export async function POST(request: NextRequest) {
           ? body.weather_snapshot.trim()
           : null;
 
+      const noiseLevelCategory = body.noiseLevelCategory ?? body.noise_level_category;
+      const heightCategoryRaw = body.height_category ?? body.heightCategory;
+      const elevationCategoryRaw = body.elevation_category ?? body.elevationCategory;
+      const exactNoiseLevelDb = body.exactNoiseLevelDb ?? body.exact_noise_level_db;
+      const exactBarometricElevationMeters =
+        body.exactBarometricElevationMeters ?? body.exact_barometric_elevation_m;
+      const clientNoiseLevelString = normalizeClientNoiseLevelString(
+        body.noise_level ?? body.noiseLevel,
+      );
+      const enumNoiseLevel = normalizeNoiseLevelCategory(noiseLevelCategory);
+      const resolvedNoiseForEncounter =
+        enumNoiseLevel ?? clientNoiseLevelString ?? normalizeNoiseLevelCategory(heightCategoryRaw);
+      const resolvedElevationCategory =
+        normalizeElevationCategoryString(elevationCategoryRaw) ??
+        normalizeElevationCategoryString(heightCategoryRaw);
+
       // Build RPC params — include scanner GPS for proximity gate
       const rpcParams: Record<string, unknown> = { p_token: token };
       if (gpsPair.lat != null && gpsPair.lon != null) {
@@ -518,6 +557,42 @@ export async function POST(request: NextRequest) {
         }
         if (resolvedWeather != null) {
           encounterInsert.weather_snapshot = resolvedWeather;
+        }
+
+        if (resolvedNoiseForEncounter != null) {
+          encounterInsert.noise_level = resolvedNoiseForEncounter;
+        }
+        if (resolvedElevationCategory != null) {
+          encounterInsert.elevation_category = resolvedElevationCategory;
+        }
+
+        const encDb = finiteNumber(exactNoiseLevelDb);
+        const encElev = finiteNumber(exactBarometricElevationMeters);
+        if (encDb != null) {
+          encounterInsert.exact_noise_level_db = encDb;
+        }
+        if (encElev != null) {
+          encounterInsert.exact_barometric_elevation_m = encElev;
+        }
+
+        let relativeAltitudeM: number | null = null;
+        if (
+          encElev != null &&
+          gpsPair.lat != null &&
+          gpsPair.lon != null &&
+          !(gpsPair.lat === 0 && gpsPair.lon === 0)
+        ) {
+          try {
+            const terrainM = await fetchTerrainElevationMeters(gpsPair.lat, gpsPair.lon);
+            if (terrainM != null) {
+              relativeAltitudeM = encElev - terrainM;
+            }
+          } catch (openElevErr) {
+            console.error('Open-Elevation lookup failed (non-fatal):', openElevErr);
+          }
+        }
+        if (relativeAltitudeM != null) {
+          encounterInsert.relative_altitude_m = relativeAltitudeM;
         }
 
         const { error: encounterErr } = await adminClient

--- a/lib/server/connectionEncounterContextTag.ts
+++ b/lib/server/connectionEncounterContextTag.ts
@@ -1,0 +1,50 @@
+export type ContextTagPayload = {
+  id: string;
+  label: string;
+  emoji: string;
+};
+
+export function normalizeContextTag(input: unknown): ContextTagPayload | null {
+  if (typeof input === 'string') {
+    const label = input.trim();
+    return label ? { id: 'custom', label, emoji: '✏️' } : null;
+  }
+
+  if (
+    input &&
+    typeof input === 'object' &&
+    'id' in input &&
+    'label' in input &&
+    typeof input.id === 'string' &&
+    typeof input.label === 'string'
+  ) {
+    const candidate = input as { id: string; label: string; emoji?: unknown };
+    return {
+      id: candidate.id,
+      label: candidate.label,
+      emoji: typeof candidate.emoji === 'string' ? candidate.emoji : '✏️',
+    };
+  }
+
+  return null;
+}
+
+export function resolveContextTagId(contextTag: ContextTagPayload | null): string | null {
+  if (!contextTag) {
+    return null;
+  }
+
+  return contextTag.id === 'custom' ? contextTag.label : contextTag.id;
+}
+
+export function normalizeNoiseLevelCategory(
+  value: unknown,
+): 'VERY_QUIET' | 'QUIET' | 'MODERATE' | 'LOUD' | 'VERY_LOUD' | null {
+  return value === 'VERY_QUIET' ||
+    value === 'QUIET' ||
+    value === 'MODERATE' ||
+    value === 'LOUD' ||
+    value === 'VERY_LOUD'
+    ? value
+    : null;
+}

--- a/lib/server/terrainElevation.ts
+++ b/lib/server/terrainElevation.ts
@@ -1,0 +1,22 @@
+/**
+ * Terrain elevation (m above sea level) at a point from Open-Elevation (SRTM-backed DEM).
+ * Mirrors `fetchTerrainElevationM` in `supabase/functions/bind-proximity-connection`.
+ */
+export const OPEN_ELEVATION_LOOKUP_TIMEOUT_MS = 8_000;
+
+export async function fetchTerrainElevationMeters(lat: number, lon: number): Promise<number | null> {
+  const url = `https://api.open-elevation.com/api/v1/lookup?locations=${lat},${lon}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPEN_ELEVATION_LOOKUP_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal, cache: 'no-store' });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { results?: { elevation?: unknown }[] };
+    const raw = data.results?.[0]?.elevation;
+    return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mobile clients send snake_case fields (`exact_barometric_elevation_m`, `exact_noise_level_db`, `noise_level`, `height_category`) when creating connections or tagging encounters. This change ensures those values are parsed, stored on `connection_encounters`, and that `relative_altitude_m` is derived when barometric elevation and GPS are both present.

## Changes

- **POST `/api/connections`**: Parse both camelCase and snake_case for sensor fields; resolve `noise_level` for the DB from enum (`noise_level_category` / `noiseLevelCategory`), free-text `noise_level`, or enum-style `height_category` when appropriate; map explicit `elevation_category` / `height_category` to `elevation_category`. After building the encounter row, call Open-Elevation (8s abort, same URL as the proximity edge function) to set `relative_altitude_m` when possible. Failures are non-blocking (try/catch + internal helper already returns null on error). GPS validation now uses `finiteNumber` so coordinates are not treated as valid when sent as strings.
- **`PATCH /api/connections/[connectionId]/tags`**: New route for post-crossing context updates—merges a new context tag into `context_tags` on the latest encounter and can patch noise, elevation category, exact dB, barometric elevation, optional GPS override, and recompute `relative_altitude_m`.
- **QR redeem path** (`app/api/qr/route.ts`): When logging an encounter for an existing connection pair, apply the same sensor and relative-altitude logic so pre-`POST /api/connections` encounter rows are not missing columns.

## Shared code

- `lib/server/terrainElevation.ts` — Open-Elevation fetch with timeout (mirrors `bind-proximity-connection`).
- `lib/server/connectionEncounterContextTag.ts` — context tag + noise enum normalization shared by POST connections and the new tags route.

## Testing

- `npm test`: one pre-existing failure in `getAuthenticatedSupabase` cookie vs header preference (unrelated to this diff).
- `npm run build` / `tsc`: environment missing optional deps (`sonner`, `@radix-ui/react-dialog`); not introduced here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f08d3b71-c4b4-4e91-8350-bcff96a4013d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f08d3b71-c4b4-4e91-8350-bcff96a4013d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

