### PR TITLE
Map beacons, venue soundtracks, and clustered map layers

### DIFF
--- a/app/api/insights/[venueId]/beacons/route.ts
+++ b/app/api/insights/[venueId]/beacons/route.ts
@@ -1,0 +1,184 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseFromRouteRequest } from "@/lib/server/supabaseRouteAuth";
+import { userMayAccessBusinessInsights } from "@/lib/server/businessInsightsEligibility";
+import { parseMapBeacon, type MapBeaconRecord } from "@/lib/map/mapBeacons";
+
+const SPOTIFY_PREFIX = "spotify:playlist:";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Venue-scoped map beacons: list active pins for managers, and post an official soundtrack beacon.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ venueId: string }> },
+) {
+  try {
+    const { venueId } = await params;
+    const { supabase, user, authError } = await getSupabaseFromRouteRequest(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!(await userMayAccessBusinessInsights(supabase, user))) {
+      return NextResponse.json(
+        { error: "Forbidden: Requires verified business or active venue subscription" },
+        { status: 403 },
+      );
+    }
+
+    const { data: membership, error: membershipError } = await supabase
+      .from("venue_managers")
+      .select("id")
+      .eq("venue_id", venueId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (membershipError) {
+      console.error("insights/[venueId]/beacons venue_managers:", membershipError.message);
+      return NextResponse.json({ error: "Failed to verify access" }, { status: 500 });
+    }
+
+    if (!membership) {
+      return NextResponse.json({ error: "Not a manager for this venue" }, { status: 403 });
+    }
+
+    const { data: rpcList, error } = await supabase.rpc("insights_venue_map_beacons_list", {
+      venue_id_param: venueId,
+    });
+
+    if (error) {
+      console.error("insights_venue_map_beacons_list:", error.message);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const rawList = Array.isArray(rpcList) ? rpcList : [];
+    const beacons: MapBeaconRecord[] = rawList.map(parseMapBeacon).filter((b): b is MapBeaconRecord => b != null);
+
+    return NextResponse.json({ beacons });
+  } catch (e) {
+    console.error("GET /api/insights/[venueId]/beacons:", e);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ venueId: string }> },
+) {
+  try {
+    const { venueId } = await params;
+    const { supabase, user, authError } = await getSupabaseFromRouteRequest(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!(await userMayAccessBusinessInsights(supabase, user))) {
+      return NextResponse.json(
+        { error: "Forbidden: Requires verified business or active venue subscription" },
+        { status: 403 },
+      );
+    }
+
+    const { data: membership, error: membershipError } = await supabase
+      .from("venue_managers")
+      .select("id")
+      .eq("venue_id", venueId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (membershipError || !membership) {
+      return NextResponse.json({ error: "Not a manager for this venue" }, { status: 403 });
+    }
+
+    const { data: venue, error: venueError } = await supabase
+      .from("venues")
+      .select("id, latitude, longitude, is_verified")
+      .eq("id", venueId)
+      .maybeSingle();
+
+    if (venueError || !venue) {
+      return NextResponse.json({ error: "Venue not found" }, { status: 404 });
+    }
+
+    if (!venue.is_verified) {
+      return NextResponse.json(
+        { error: "Venue must be verified to broadcast an official soundtrack" },
+        { status: 403 },
+      );
+    }
+
+    const lat = typeof venue.latitude === "number" ? venue.latitude : null;
+    const lng = typeof venue.longitude === "number" ? venue.longitude : null;
+    if (lat == null || lng == null || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return NextResponse.json(
+        { error: "Venue latitude and longitude are required to place the official soundtrack" },
+        { status: 400 },
+      );
+    }
+
+    let body: { spotify_playlist_uri?: unknown };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const uri =
+      typeof body.spotify_playlist_uri === "string" ? body.spotify_playlist_uri.trim() : "";
+    if (!uri.startsWith(SPOTIFY_PREFIX) || uri.length > 512) {
+      return NextResponse.json(
+        { error: "spotify_playlist_uri must be a spotify:playlist: URI (max 512 chars)" },
+        { status: 400 },
+      );
+    }
+
+    const metadata = {
+      is_official: true,
+      spotify_playlist_uri: uri,
+      label: "Official Soundtrack",
+    };
+
+    const { data: inserted, error: insertError } = await supabase
+      .from("map_beacons")
+      .insert({
+        creator_id: user.id,
+        venue_id: venueId,
+        beacon_type: "soundtrack",
+        location: `POINT(${lng} ${lat})`,
+        metadata,
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .select("id, creator_id, venue_id, beacon_type, metadata, created_at, expires_at, location")
+      .maybeSingle();
+
+    if (insertError) {
+      console.error("map_beacons insert official:", insertError.message);
+      return NextResponse.json({ error: insertError.message }, { status: 400 });
+    }
+
+    if (!inserted || !isRecord(inserted)) {
+      return NextResponse.json({ error: "Insert failed" }, { status: 500 });
+    }
+
+    const loc = inserted.location as unknown;
+    const wktMatch = typeof loc === "string" ? /POINT\s*\(\s*([-\d.]+)\s+([-\d.]+)\s*\)/i.exec(loc) : null;
+    const parsed =
+      wktMatch != null
+        ? { lng: Number(wktMatch[1]), lat: Number(wktMatch[2]) }
+        : { lng, lat };
+    const beacon = parseMapBeacon({
+      ...inserted,
+      lat: parsed.lat,
+      lng: parsed.lng,
+    });
+
+    return NextResponse.json({ beacon });
+  } catch (e) {
+    console.error("POST /api/insights/[venueId]/beacons:", e);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/app/api/insights/[venueId]/beacons/route.ts
+++ b/app/api/insights/[venueId]/beacons/route.ts
@@ -129,7 +129,7 @@ export async function POST(
 
     const uri =
       typeof body.spotify_playlist_uri === "string" ? body.spotify_playlist_uri.trim() : "";
-    if (!uri.startsWith(SPOTIFY_PREFIX) || uri.length > 512) {
+    if (!uri.startsWith(SPOTIFY_PREFIX) || uri.length <= SPOTIFY_PREFIX.length || uri.length > 512) {
       return NextResponse.json(
         { error: "spotify_playlist_uri must be a spotify:playlist: URI (max 512 chars)" },
         { status: 400 },

--- a/app/api/insights/intents/route.ts
+++ b/app/api/insights/intents/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseFromRouteRequest } from "@/lib/server/supabaseRouteAuth";
 import { userMayAccessBusinessInsights } from "@/lib/server/businessInsightsEligibility";
 import { resolveInsightsVenueId } from "@/lib/server/resolveInsightsVenueId";
-import { parseVibeRadarRpcPayload, type VibeRadarApiResponse } from "@/lib/insights/vibeRadar";
+import {
+  parseVibeRadarRpcPayload,
+  parseVibeRadarBeaconDensityRpc,
+  type VibeRadarApiResponse,
+} from "@/lib/insights/vibeRadar";
 
 /**
  * Aggregated availability intent clusters near the venue (no user-level data).
@@ -67,9 +71,22 @@ export async function GET(request: NextRequest) {
     }
 
     const parsed = parseVibeRadarRpcPayload(rpcData);
+
+    let trendingVibes = undefined as VibeRadarApiResponse["trendingVibes"];
+    const { data: densityRaw, error: densityError } = await supabase.rpc(
+      "insights_vibe_radar_beacon_density",
+      { venue_id_param: venueId },
+    );
+    if (densityError) {
+      console.warn("insights_vibe_radar_beacon_density:", densityError.message);
+    } else {
+      trendingVibes = parseVibeRadarBeaconDensityRpc(densityRaw);
+    }
+
     const body: VibeRadarApiResponse = {
       ...parsed,
       venueId,
+      trendingVibes,
     };
 
     return NextResponse.json(body);

--- a/app/api/map/beacons/route.ts
+++ b/app/api/map/beacons/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseFromRouteRequest } from "@/lib/server/supabaseRouteAuth";
+import { parseMapBeacon, type MapBeaconRecord } from "@/lib/map/mapBeacons";
+
+const DEFAULT_RADIUS = 15_000;
+const MIN_RADIUS = 100;
+const MAX_RADIUS = 50_000;
+
+/**
+ * Proximity beacons for the signed-in user's map (RLS: active rows only).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { supabase, user, authError } = await getSupabaseFromRouteRequest(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const lat = Number(searchParams.get("lat"));
+    const lng = Number(searchParams.get("lng"));
+    const radiusRaw = searchParams.get("radius_m");
+    const radius_m =
+      radiusRaw != null && radiusRaw.length > 0
+        ? Number(radiusRaw)
+        : DEFAULT_RADIUS;
+
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return NextResponse.json(
+        { error: "Query params lat and lng must be finite numbers" },
+        { status: 400 },
+      );
+    }
+
+    const radius = Math.min(MAX_RADIUS, Math.max(MIN_RADIUS, Number.isFinite(radius_m) ? radius_m : DEFAULT_RADIUS));
+
+    const { data, error } = await supabase.rpc("fetch_map_beacons_within", {
+      lat,
+      lng,
+      radius_meters: radius,
+    });
+
+    if (error) {
+      console.error("fetch_map_beacons_within:", error.message);
+      return NextResponse.json({ error: "Failed to load beacons", detail: error.message }, { status: 500 });
+    }
+
+    const rawList = Array.isArray(data) ? data : [];
+    const beacons: MapBeaconRecord[] = rawList.map(parseMapBeacon).filter((b): b is MapBeaconRecord => b != null);
+
+    return NextResponse.json({ beacons, radius_meters: radius });
+  } catch (e) {
+    console.error("GET /api/map/beacons:", e);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/components/dashboard/ConnectionMap.tsx
+++ b/components/dashboard/ConnectionMap.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import { MapPin, Loader2 } from 'lucide-react';
+import { MapPin, Loader2, Layers } from 'lucide-react';
 import type { ConnectionRecord } from './ConnectionTable';
 import { escapeHtml } from '@/lib/dashboard/connectionExtras';
+import { getSupabaseClient } from '@/lib/supabase';
+import {
+  DEFAULT_MAP_LAYER_TOGGLES,
+  type MapLayerToggles,
+  type MapBeaconRecord,
+  beaconGeoJsonFeatures,
+  parseMapBeacon,
+} from '@/lib/map/mapBeacons';
 
 function atmosphereHtml(conn: ConnectionRecord): string {
   const bits = [conn.weatherSummary, conn.noiseSummary].filter((b): b is string => typeof b === 'string' && b.length > 0);
@@ -54,8 +62,6 @@ const spreadOverlappingConnections = (input: ConnectionRecord[]): PositionedConn
 
   const clusters: ConnectionRecord[][] = [];
 
-  // Greedy clustering around each group's anchor point (first member) prevents
-  // transitive chain-merges that can move grouped dots far from expected locations.
   sorted.forEach((connection) => {
     const targetCluster = clusters.find((cluster) => {
       const anchor = cluster[0];
@@ -95,24 +101,50 @@ const spreadOverlappingConnections = (input: ConnectionRecord[]): PositionedConn
   return positioned;
 };
 
+const SRC_CONNECTIONS = 'connections-geo';
+const SRC_OFFICIAL = 'beacons-official-geo';
+const SRC_COMMUNITY = 'beacons-community-geo';
+const SRC_HAZARDS = 'beacons-hazards-geo';
+
+const CLUSTER_MAX_ZOOM = 14;
+const CLUSTER_RADIUS = 52;
+
+function emptyFc() {
+  return { type: 'FeatureCollection' as const, features: [] as GeoJSON.Feature[] };
+}
+
+function buildConnectionFeatures(positioned: PositionedConnection[]): GeoJSON.Feature[] {
+  return positioned.map((pc) => ({
+    type: 'Feature' as const,
+    geometry: {
+      type: 'Point' as const,
+      coordinates: [pc.markerLongitude, pc.markerLatitude],
+    },
+    properties: {
+      count: pc.groupedConnections.length,
+      connIds: pc.groupedConnections.map((c) => c.id).join(','),
+    },
+  }));
+}
+
 /**
- * MapLibre GL map for connection locations.
+ * MapLibre GL map for connection locations + optional map beacon layers (clustered).
  *
- * **Data contract:** pass rows from `GET /api/connections?statusScope=map` (or equivalent):
- * every connection the user participates in **except** those in `connection_hidden`.
- * That includes per-user archived and legacy server-archived rows so the memory map matches full history.
+ * **Data contract:** pass rows from `GET /api/connections?statusScope=map` (or equivalent).
  */
 export default function ConnectionMap({ connections, onConnectionClick }: ConnectionMapProps) {
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<maplibregl.Map | null>(null);
-  const markersRef = useRef<maplibregl.Marker[]>([]);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [mapError, setMapError] = useState<string | null>(null);
-  // Keep a ref to connections so event delegation can read them without stale closures
+  const [layers, setLayers] = useState<MapLayerToggles>(() => ({ ...DEFAULT_MAP_LAYER_TOGGLES }));
+  const [beacons, setBeacons] = useState<MapBeaconRecord[]>([]);
   const connectionsRef = useRef(connections);
+  const onConnectionClickRef = useRef(onConnectionClick);
   useEffect(() => { connectionsRef.current = connections; }, [connections]);
+  useEffect(() => { onConnectionClickRef.current = onConnectionClick; }, [onConnectionClick]);
 
-  // Filter connections with valid geo_location (exclude NaN, null, and 0,0 sentinel values)
   const geoConnections = connections.filter(c => {
     if (!c.geo_location) return false;
     const { latitude, longitude } = c.geo_location;
@@ -125,180 +157,380 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
   const positionedConnections = spreadOverlappingConnections(geoConnections);
   const hasGeoConnections = geoConnections.length > 0;
 
-  // Initialize map
+  const mapCenter = useMemo((): [number, number] => {
+    if (hasGeoConnections && geoConnections[0]?.geo_location) {
+      const g = geoConnections[0].geo_location;
+      return [g.longitude, g.latitude];
+    }
+    return [-122.3321, 47.6062];
+  }, [hasGeoConnections, geoConnections]);
+
+  const mapInitCenterRef = useRef<[number, number] | null>(null);
+  if (mapInitCenterRef.current === null) {
+    mapInitCenterRef.current = mapCenter;
+  }
+
+  const wantsBeaconFetch = layers.officialSoundtracks || layers.communityBeacons || layers.hazards;
+
+  useEffect(() => {
+    if (!wantsBeaconFetch) {
+      setBeacons([]);
+      return;
+    }
+    const [lng, lat] = mapCenter;
+    let cancelled = false;
+
+    const run = async () => {
+      const supabase = getSupabaseClient();
+      const token = supabase ? (await supabase.auth.getSession()).data.session?.access_token : undefined;
+      const headers: HeadersInit = { Accept: 'application/json' };
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const url = `/api/map/beacons?lat=${encodeURIComponent(String(lat))}&lng=${encodeURIComponent(String(lng))}&radius_m=15000`;
+      try {
+        const res = await fetch(url, { credentials: 'include', headers });
+        const payload = (await res.json()) as { beacons?: unknown[] };
+        if (cancelled) return;
+        const list = Array.isArray(payload.beacons) ? payload.beacons : [];
+        setBeacons(list.map(parseMapBeacon).filter((b): b is MapBeaconRecord => b != null));
+      } catch {
+        if (!cancelled) setBeacons([]);
+      }
+    };
+
+    void run();
+    return () => { cancelled = true; };
+  }, [wantsBeaconFetch, mapCenter[0], mapCenter[1]]);
+
+  const buildConnectionPopupHtml = useCallback((connIdsCsv: string) => {
+    const ids = connIdsCsv.split(',').filter(Boolean);
+    const groupedConnections = ids
+      .map((id) => connectionsRef.current.find((c) => c.id === id))
+      .filter((c): c is ConnectionRecord => c != null);
+    if (groupedConnections.length === 0) return '';
+
+    const connection = groupedConnections
+      .slice()
+      .sort((a, b) => b.dateMet.getTime() - a.dateMet.getTime())[0];
+
+    const groupedRows = groupedConnections
+      .map((conn) => {
+        const date = conn.dateMet.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
+        const ctx = conn.context
+          ? `<span style="color:#8338EC; font-size:10px; display:inline-block; margin-top:6px; padding:2px 8px; background:rgba(131,56,236,0.2); border-radius:9999px;">${escapeHtml(conn.context)}</span>`
+          : '';
+        const atm = atmosphereHtml(conn);
+        return `<div style="padding:8px 0; border-bottom:1px solid rgba(63,63,70,0.35);">
+          <strong style="color:#8338EC; font-size:13px; display:block; margin-bottom:2px;">${escapeHtml(conn.name)}</strong>
+          <span style="color:#a1a1aa; font-size:11px; display:block;">${escapeHtml(conn.location)}</span>
+          <span style="color:#71717a; font-size:10px; display:block; margin-top:4px;">${escapeHtml(date)}</span>
+          ${ctx}${atm}
+          <button data-conn-id="${conn.id}" style="display:block; width:100%; margin-top:8px; padding:5px 10px; background:linear-gradient(135deg, #8338EC, #6520c0); color:white; font-size:11px; font-weight:600; border:none; border-radius:8px; cursor:pointer; text-align:center;">
+            Chat →
+          </button>
+        </div>`;
+      })
+      .join('');
+
+    const single = groupedConnections.length === 1;
+    const singleDate = connection.dateMet.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
+    const singleCtx = connection.context
+      ? `<span style="color: #8338EC; font-size: 10px; display: inline-block; margin-top: 8px; padding: 2px 8px; background: rgba(131, 56, 236, 0.2); border-radius: 9999px;">${escapeHtml(connection.context)}</span>`
+      : '';
+    const singleAtm = atmosphereHtml(connection);
+
+    return `<div style="color: white; background: #18181b; padding: 14px; border-radius: 14px; border: 1px solid #27272a; box-shadow: 0 8px 32px rgba(0,0,0,0.4); max-height: 260px; overflow-y: auto;">
+      ${single ? `<strong style="color: #8338EC; font-size: 14px; display: block; margin-bottom: 4px;">${escapeHtml(connection.name)}</strong>
+      <span style="color: #a1a1aa; font-size: 12px; display: block;">${escapeHtml(connection.location)}</span>
+      <span style="color: #71717a; font-size: 11px; display: block; margin-top: 6px;">${escapeHtml(singleDate)}</span>
+      ${singleCtx}${singleAtm}
+      <button data-conn-id="${connection.id}" style="display: block; width: 100%; margin-top: 10px; padding: 6px 12px; background: linear-gradient(135deg, #8338EC, #6520c0); color: white; font-size: 12px; font-weight: 600; border: none; border-radius: 8px; cursor: pointer; text-align: center;">Chat →</button>`
+      : `<strong style="color:#8338EC; font-size:14px; display:block; margin-bottom:6px;">${groupedConnections.length} connections at this location</strong>${groupedRows}`}
+    </div>`;
+  }, []);
+
+  const attachMapInteractions = useCallback((mapInstance: maplibregl.Map) => {
+    const onConnClusterClick = (e: maplibregl.MapLayerMouseEvent) => {
+      const f = e.features?.[0];
+      if (!f || f.geometry.type !== 'Point') return;
+      const clusId = f.properties?.cluster_id;
+      const src = mapInstance.getSource(SRC_CONNECTIONS) as maplibregl.GeoJSONSource | undefined;
+      if (clusId == null || !src || typeof src.getClusterExpansionZoom !== 'function') return;
+      src.getClusterExpansionZoom(clusId as number).then((z) => {
+        const coords = (f.geometry as GeoJSON.Point).coordinates as [number, number];
+        mapInstance.easeTo({ center: coords, zoom: z + 0.35, duration: 420 });
+      }).catch(() => {});
+    };
+
+    const onConnPointClick = (e: maplibregl.MapLayerMouseEvent) => {
+      const f = e.features?.[0];
+      const csv = f?.properties?.connIds;
+      if (typeof csv !== 'string') return;
+      popupRef.current?.remove();
+      const html = buildConnectionPopupHtml(csv);
+      const popup = new maplibregl.Popup({ offset: 18, closeButton: false, maxWidth: '280px' }).setLngLat(e.lngLat).setHTML(html);
+      popup.addTo(mapInstance);
+      popupRef.current = popup;
+    };
+
+    const beaconClusterClick = (sourceId: string) => (e: maplibregl.MapLayerMouseEvent) => {
+      const f = e.features?.[0];
+      if (!f || f.geometry.type !== 'Point') return;
+      const clusId = f.properties?.cluster_id;
+      const src = mapInstance.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (clusId == null || !src || typeof src.getClusterExpansionZoom !== 'function') return;
+      src.getClusterExpansionZoom(clusId as number).then((z) => {
+        const coords = (f.geometry as GeoJSON.Point).coordinates as [number, number];
+        mapInstance.easeTo({ center: coords, zoom: z + 0.35, duration: 420 });
+      }).catch(() => {});
+    };
+
+    const onBeaconPointClick = (e: maplibregl.MapLayerMouseEvent) => {
+      const f = e.features?.[0];
+      if (!f) return;
+      const title = escapeHtml(String(f.properties?.title ?? 'Beacon'));
+      const typ = escapeHtml(String(f.properties?.beacon_type ?? ''));
+      const spotify = typeof f.properties?.spotify === 'string' ? f.properties.spotify : '';
+      const open = spotify
+        ? `<a href="${escapeHtml(spotify)}" target="_blank" rel="noreferrer" style="display:inline-block;margin-top:10px;color:#67e8f9;font-size:12px;">Open in Spotify →</a>`
+        : '';
+      popupRef.current?.remove();
+      const html = `<div style="color:#fff;background:#18181b;padding:12px 14px;border-radius:12px;border:1px solid #27272a;max-width:240px;">
+        <div style="font-weight:600;color:#e4e4e7;margin-bottom:4px;">${title}</div>
+        <div style="font-size:11px;color:#a1a1aa;">${typ}</div>
+        ${open}
+      </div>`;
+      const popup = new maplibregl.Popup({ offset: 14, closeButton: true, maxWidth: '260px' }).setLngLat(e.lngLat).setHTML(html);
+      popup.addTo(mapInstance);
+      popupRef.current = popup;
+    };
+
+    mapInstance.on('click', 'connection-clusters', onConnClusterClick);
+    mapInstance.on('click', 'connection-unclustered', onConnPointClick);
+    mapInstance.on('click', 'official-beacon-clusters', beaconClusterClick(SRC_OFFICIAL));
+    mapInstance.on('click', 'official-beacon-unclustered', onBeaconPointClick);
+    mapInstance.on('click', 'community-beacon-clusters', beaconClusterClick(SRC_COMMUNITY));
+    mapInstance.on('click', 'community-beacon-unclustered', onBeaconPointClick);
+    mapInstance.on('click', 'hazard-beacon-clusters', beaconClusterClick(SRC_HAZARDS));
+    mapInstance.on('click', 'hazard-beacon-unclustered', onBeaconPointClick);
+
+    mapInstance.on('mouseenter', 'connection-clusters', () => { mapInstance.getCanvas().style.cursor = 'pointer'; });
+    mapInstance.on('mouseleave', 'connection-clusters', () => { mapInstance.getCanvas().style.cursor = ''; });
+    mapInstance.on('mouseenter', 'connection-unclustered', () => { mapInstance.getCanvas().style.cursor = 'pointer'; });
+    mapInstance.on('mouseleave', 'connection-unclustered', () => { mapInstance.getCanvas().style.cursor = ''; });
+    ['official-beacon-clusters', 'official-beacon-unclustered', 'community-beacon-clusters', 'community-beacon-unclustered', 'hazard-beacon-clusters', 'hazard-beacon-unclustered'].forEach((id) => {
+      mapInstance.on('mouseenter', id, () => { mapInstance.getCanvas().style.cursor = 'pointer'; });
+      mapInstance.on('mouseleave', id, () => { mapInstance.getCanvas().style.cursor = ''; });
+    });
+  }, [buildConnectionPopupHtml]);
+
   useEffect(() => {
     if (!mapContainer.current || map.current) return;
-
-    // Calculate center from connections or use Seattle default
-    const initialCenter: [number, number] = hasGeoConnections && geoConnections[0]?.geo_location
-      ? [geoConnections[0].geo_location.longitude, geoConnections[0].geo_location.latitude]
-      : [-122.3321, 47.6062]; // Seattle default
 
     try {
       const mapInstance = new maplibregl.Map({
         container: mapContainer.current,
         style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
-        center: initialCenter,
+        center: mapInitCenterRef.current ?? mapCenter,
         zoom: 12,
         attributionControl: false,
       });
 
       map.current = mapInstance;
-
-      // Add navigation controls
       mapInstance.addControl(new maplibregl.NavigationControl(), 'top-right');
 
-      // Handle map load
       mapInstance.on('load', () => {
-        setMapLoaded(true);
-
-        // Resize to ensure proper rendering
-        mapInstance.resize();
-
-        // Add markers
-        positionedConnections.forEach(({ connection, markerLatitude, markerLongitude, groupedConnections }) => {
-          if (connection.geo_location) {
-            // Zero-size anchor div: MapLibre positions this 0×0 point exactly at the
-            // coordinate (no offsetWidth/offsetHeight measurement needed), so the dot
-            // never drifts at any zoom level.
-            const anchor = document.createElement('div');
-            anchor.style.cssText = 'position: relative; width: 0; height: 0;';
-
-            const el = document.createElement('div');
-            el.className = 'connection-marker';
-            // translate(-50%, -50%) centers the dot on the anchor point regardless of
-            // its size, which also means the grow-on-hover effect stays perfectly centered.
-            el.style.cssText = 'position: absolute; transform: translate(-50%, -50%); width: 28px; height: 28px; border-radius: 50%; background: linear-gradient(135deg, #8338EC, #3A86FF); border: 3px solid white; cursor: pointer; box-shadow: 0 0 16px rgba(131, 56, 236, 0.6); transition: box-shadow 0.2s ease, width 0.2s ease, height 0.2s ease;';
-            el.onmouseenter = () => { el.style.width = '34px'; el.style.height = '34px'; el.style.boxShadow = '0 0 24px rgba(131, 56, 236, 0.8)'; };
-            el.onmouseleave = () => { el.style.width = '28px'; el.style.height = '28px'; el.style.boxShadow = '0 0 16px rgba(131, 56, 236, 0.6)'; };
-
-            if (groupedConnections.length > 1) {
-              const badge = document.createElement('div');
-              badge.style.cssText = 'position:absolute; right:-8px; top:-8px; min-width:18px; height:18px; padding:0 4px; border-radius:9999px; background:#18181b; color:#C3A6FF; border:1px solid #8338EC; font-size:11px; font-weight:700; display:flex; align-items:center; justify-content:center; line-height:1;';
-              badge.textContent = String(groupedConnections.length);
-              // el is already position:absolute so it creates a positioning context
-              // for the badge — no need to override position here.
-              el.appendChild(badge);
-            }
-
-            anchor.appendChild(el);
-
-            const groupedRows = groupedConnections
-              .map((conn) => {
-                const date = conn.dateMet.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
-                const ctx = conn.context
-                  ? `<span style="color:#8338EC; font-size:10px; display:inline-block; margin-top:6px; padding:2px 8px; background:rgba(131,56,236,0.2); border-radius:9999px;">${escapeHtml(conn.context)}</span>`
-                  : '';
-                const atm = atmosphereHtml(conn);
-                return `<div style="padding:8px 0; border-bottom:1px solid rgba(63,63,70,0.35);">
-                  <strong style="color:#8338EC; font-size:13px; display:block; margin-bottom:2px;">${escapeHtml(conn.name)}</strong>
-                  <span style="color:#a1a1aa; font-size:11px; display:block;">${escapeHtml(conn.location)}</span>
-                  <span style="color:#71717a; font-size:10px; display:block; margin-top:4px;">${escapeHtml(date)}</span>
-                  ${ctx}${atm}
-                  <button data-conn-id="${conn.id}" style="display:block; width:100%; margin-top:8px; padding:5px 10px; background:linear-gradient(135deg, #8338EC, #6520c0); color:white; font-size:11px; font-weight:600; border:none; border-radius:8px; cursor:pointer; text-align:center;">
-                    Chat →
-                  </button>
-                </div>`;
-              })
-              .join('');
-
-            const single = groupedConnections.length === 1;
-            const singleDate = connection.dateMet.toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' });
-            const singleCtx = connection.context
-              ? `<span style="color: #8338EC; font-size: 10px; display: inline-block; margin-top: 8px; padding: 2px 8px; background: rgba(131, 56, 236, 0.2); border-radius: 9999px;">${escapeHtml(connection.context)}</span>`
-              : '';
-            const singleAtm = atmosphereHtml(connection);
-            const popupContent = `<div style="color: white; background: #18181b; padding: 14px; border-radius: 14px; border: 1px solid #27272a; box-shadow: 0 8px 32px rgba(0,0,0,0.4); max-height: 260px; overflow-y: auto;">
-              ${single ? `<strong style="color: #8338EC; font-size: 14px; display: block; margin-bottom: 4px;">${escapeHtml(connection.name)}</strong>
-              <span style="color: #a1a1aa; font-size: 12px; display: block;">${escapeHtml(connection.location)}</span>
-              <span style="color: #71717a; font-size: 11px; display: block; margin-top: 6px;">${escapeHtml(singleDate)}</span>
-              ${singleCtx}${singleAtm}
-              <button data-conn-id="${connection.id}" style="display: block; width: 100%; margin-top: 10px; padding: 6px 12px; background: linear-gradient(135deg, #8338EC, #6520c0); color: white; font-size: 12px; font-weight: 600; border: none; border-radius: 8px; cursor: pointer; text-align: center;">Chat →</button>`
-              : `<strong style="color:#8338EC; font-size:14px; display:block; margin-bottom:6px;">${groupedConnections.length} connections at this location</strong>${groupedRows}`}
-            </div>`;
-
-            const popup = new maplibregl.Popup({
-              offset: 25,
-              closeButton: false,
-              maxWidth: '280px',
-            }).setHTML(popupContent);
-
-            const marker = new maplibregl.Marker({ element: anchor })
-              .setLngLat([markerLongitude, markerLatitude])
-              .setPopup(popup)
-              .addTo(mapInstance);
-
-            markersRef.current.push(marker);
-          }
+        mapInstance.addSource(SRC_CONNECTIONS, {
+          type: 'geojson',
+          data: emptyFc(),
+          cluster: true,
+          clusterMaxZoom: CLUSTER_MAX_ZOOM,
+          clusterRadius: CLUSTER_RADIUS,
         });
 
-        // Fit bounds to show all markers if we have multiple
-        if (geoConnections.length > 1) {
-          const bounds = new maplibregl.LngLatBounds();
-          geoConnections.forEach(conn => {
-            if (conn.geo_location) {
-              bounds.extend([conn.geo_location.longitude, conn.geo_location.latitude]);
-            }
+        mapInstance.addLayer({
+          id: 'connection-clusters',
+          type: 'circle',
+          source: SRC_CONNECTIONS,
+          filter: ['has', 'point_count'],
+          paint: {
+            'circle-color': '#6520c0',
+            'circle-radius': ['step', ['get', 'point_count'], 20, 10, 24, 28, 30],
+            'circle-opacity': 0.92,
+            'circle-stroke-width': 2,
+            'circle-stroke-color': '#ffffff',
+          },
+        });
+        mapInstance.addLayer({
+          id: 'connection-cluster-count',
+          type: 'symbol',
+          source: SRC_CONNECTIONS,
+          filter: ['has', 'point_count'],
+          layout: {
+            'text-field': ['get', 'point_count_abbreviated'],
+            'text-size': 12,
+          },
+          paint: { 'text-color': '#ffffff' },
+        });
+        mapInstance.addLayer({
+          id: 'connection-unclustered',
+          type: 'circle',
+          source: SRC_CONNECTIONS,
+          filter: ['!', ['has', 'point_count']],
+          paint: {
+            'circle-color': '#8338EC',
+            'circle-radius': 14,
+            'circle-opacity': 0.95,
+            'circle-stroke-width': 3,
+            'circle-stroke-color': '#ffffff',
+          },
+        });
+
+        const addBeaconStack = (sourceId: string, prefix: string, defaultColor: string) => {
+          mapInstance.addSource(sourceId, {
+            type: 'geojson',
+            data: emptyFc(),
+            cluster: true,
+            clusterMaxZoom: CLUSTER_MAX_ZOOM,
+            clusterRadius: CLUSTER_RADIUS + 4,
           });
-          mapInstance.fitBounds(bounds, { padding: 60, maxZoom: 14 });
-        }
+          mapInstance.addLayer({
+            id: `${prefix}-clusters`,
+            type: 'circle',
+            source: sourceId,
+            filter: ['has', 'point_count'],
+            paint: {
+              'circle-color': defaultColor,
+              'circle-radius': ['step', ['get', 'point_count'], 18, 8, 22, 20, 26],
+              'circle-opacity': 0.88,
+              'circle-stroke-width': 2,
+              'circle-stroke-color': 'rgba(255,255,255,0.85)',
+            },
+          });
+          mapInstance.addLayer({
+            id: `${prefix}-cluster-count`,
+            type: 'symbol',
+            source: sourceId,
+            filter: ['has', 'point_count'],
+            layout: {
+              'text-field': ['get', 'point_count_abbreviated'],
+              'text-size': 11,
+            },
+            paint: { 'text-color': '#0a0a0a' },
+          });
+          mapInstance.addLayer({
+            id: `${prefix}-unclustered`,
+            type: 'circle',
+            source: sourceId,
+            filter: ['!', ['has', 'point_count']],
+            paint: {
+              'circle-color': ['get', 'tint'],
+              'circle-radius': 11,
+              'circle-opacity': 0.95,
+              'circle-stroke-width': 2,
+              'circle-stroke-color': '#ffffff',
+            },
+          });
+        };
+
+        addBeaconStack(SRC_OFFICIAL, 'official-beacon', '#22d3ee');
+        addBeaconStack(SRC_COMMUNITY, 'community-beacon', '#34d399');
+        addBeaconStack(SRC_HAZARDS, 'hazard-beacon', '#f97316');
+
+        attachMapInteractions(mapInstance);
+        setMapLoaded(true);
+        mapInstance.resize();
       });
 
-      // Handle map errors
       mapInstance.on('error', (e) => {
         console.error('Map error:', e);
         setMapError('Failed to load map tiles');
       });
-
     } catch (err) {
       console.error('Failed to initialize map:', err);
       setMapError('Failed to initialize map');
     }
 
-    // Event delegation for popup "Chat" buttons
     const handlePopupClick = (e: MouseEvent) => {
       const btn = (e.target as HTMLElement).closest('[data-conn-id]') as HTMLElement | null;
-      if (btn && onConnectionClick) {
+      const openChat = onConnectionClickRef.current;
+      if (btn && openChat) {
         const id = btn.getAttribute('data-conn-id');
         const conn = connectionsRef.current.find(c => c.id === id);
-        if (conn) onConnectionClick(conn);
+        if (conn) openChat(conn);
       }
     };
     mapContainer.current.addEventListener('click', handlePopupClick);
 
-    // Cleanup on unmount
     return () => {
       mapContainer.current?.removeEventListener('click', handlePopupClick);
-      markersRef.current.forEach(marker => marker.remove());
-      markersRef.current = [];
+      popupRef.current?.remove();
+      popupRef.current = null;
       if (map.current) {
         map.current.remove();
         map.current = null;
       }
       setMapLoaded(false);
     };
-  }, [positionedConnections, hasGeoConnections, geoConnections]);
+  }, [attachMapInteractions]);
 
-  // Handle resize
   useEffect(() => {
-    const handleResize = () => {
-      if (map.current && mapLoaded) {
-        map.current.resize();
-      }
+    const m = map.current;
+    if (!m || !mapLoaded) return;
+    const fc = { type: 'FeatureCollection' as const, features: buildConnectionFeatures(positionedConnections) };
+    const src = m.getSource(SRC_CONNECTIONS) as maplibregl.GeoJSONSource | undefined;
+    src?.setData(fc);
+
+    const vis = layers.myNetwork ? 'visible' : 'none';
+    ['connection-clusters', 'connection-cluster-count', 'connection-unclustered'].forEach((id) => {
+      if (m.getLayer(id)) m.setLayoutProperty(id, 'visibility', vis);
+    });
+
+    if (geoConnections.length > 1) {
+      const bounds = new maplibregl.LngLatBounds();
+      geoConnections.forEach(conn => {
+        if (conn.geo_location) bounds.extend([conn.geo_location.longitude, conn.geo_location.latitude]);
+      });
+      m.fitBounds(bounds, { padding: 60, maxZoom: 14, duration: 0 });
+    }
+  }, [mapLoaded, positionedConnections, geoConnections, layers.myNetwork]);
+
+  useEffect(() => {
+    const m = map.current;
+    if (!m || !mapLoaded) return;
+    const setSrc = (id: string, feats: GeoJSON.Feature[]) => {
+      const src = m.getSource(id) as maplibregl.GeoJSONSource | undefined;
+      src?.setData({ type: 'FeatureCollection', features: feats });
     };
+    setSrc(SRC_OFFICIAL, beaconGeoJsonFeatures(beacons, 'official'));
+    setSrc(SRC_COMMUNITY, beaconGeoJsonFeatures(beacons, 'community'));
+    setSrc(SRC_HAZARDS, beaconGeoJsonFeatures(beacons, 'hazard'));
 
+    const vis = (on: boolean) => (on ? 'visible' : 'none');
+    ['official-beacon-clusters', 'official-beacon-cluster-count', 'official-beacon-unclustered'].forEach((lid) => {
+      if (m.getLayer(lid)) m.setLayoutProperty(lid, 'visibility', vis(layers.officialSoundtracks));
+    });
+    ['community-beacon-clusters', 'community-beacon-cluster-count', 'community-beacon-unclustered'].forEach((lid) => {
+      if (m.getLayer(lid)) m.setLayoutProperty(lid, 'visibility', vis(layers.communityBeacons));
+    });
+    ['hazard-beacon-clusters', 'hazard-beacon-cluster-count', 'hazard-beacon-unclustered'].forEach((lid) => {
+      if (m.getLayer(lid)) m.setLayoutProperty(lid, 'visibility', vis(layers.hazards));
+    });
+  }, [mapLoaded, beacons, layers.officialSoundtracks, layers.communityBeacons, layers.hazards]);
+
+  useEffect(() => {
+    const handleResize = () => { map.current?.resize(); };
     window.addEventListener('resize', handleResize);
-
-    // Initial resize after a short delay
     const resizeTimer = setTimeout(handleResize, 100);
-
     return () => {
       window.removeEventListener('resize', handleResize);
       clearTimeout(resizeTimer);
     };
   }, [mapLoaded]);
 
-  // Show empty state if no geo connections
+  const toggle = (key: keyof MapLayerToggles) => {
+    setLayers((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
   if (!hasGeoConnections) {
     return (
       <div className="glass p-12 rounded-3xl border border-zinc-800 text-center">
@@ -311,7 +543,6 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
     );
   }
 
-  // Show error state
   if (mapError) {
     return (
       <div className="glass p-12 rounded-3xl border border-zinc-800 text-center">
@@ -324,7 +555,6 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
 
   return (
     <div className="relative rounded-3xl border border-zinc-800 overflow-hidden bg-zinc-900 h-[600px]">
-      {/* Loading overlay */}
       {!mapLoaded && (
         <div className="absolute inset-0 flex items-center justify-center bg-zinc-900 z-10">
           <div className="text-center">
@@ -334,13 +564,33 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
         </div>
       )}
 
-      {/* Map container */}
-      <div
-        ref={mapContainer}
-        className="absolute inset-0"
-      />
+      <div ref={mapContainer} className="absolute inset-0" />
 
-      {/* Connection count badge */}
+      {mapLoaded && (
+        <div className="absolute top-4 left-4 z-[6] max-w-[220px] rounded-2xl border border-white/10 bg-zinc-950/70 backdrop-blur-xl shadow-lg shadow-black/40 p-3 text-xs text-zinc-200">
+          <div className="flex items-center gap-2 mb-2 font-semibold text-white">
+            <Layers className="w-3.5 h-3.5 text-[#8338EC]" />
+            Map layers
+          </div>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input type="checkbox" className="accent-[#8338EC]" checked={layers.myNetwork} onChange={() => toggle('myNetwork')} />
+            My Network
+          </label>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input type="checkbox" className="accent-[#8338EC]" checked={layers.officialSoundtracks} onChange={() => toggle('officialSoundtracks')} />
+            Official Soundtracks
+          </label>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input type="checkbox" className="accent-[#8338EC]" checked={layers.communityBeacons} onChange={() => toggle('communityBeacons')} />
+            Community Beacons
+          </label>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input type="checkbox" className="accent-[#8338EC]" checked={layers.hazards} onChange={() => toggle('hazards')} />
+            Hazards
+          </label>
+        </div>
+      )}
+
       {mapLoaded && (
         <div className="absolute bottom-4 left-4 bg-zinc-900/90 backdrop-blur-sm px-4 py-2 rounded-xl border border-zinc-700">
           <span className="text-sm text-zinc-400">

--- a/components/dashboard/ConnectionMap.tsx
+++ b/components/dashboard/ConnectionMap.tsx
@@ -136,6 +136,7 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<maplibregl.Map | null>(null);
   const popupRef = useRef<maplibregl.Popup | null>(null);
+  const initialFitDoneRef = useRef(false);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [mapError, setMapError] = useState<string | null>(null);
   const [layers, setLayers] = useState<MapLayerToggles>(() => ({ ...DEFAULT_MAP_LAYER_TOGGLES }));
@@ -465,6 +466,7 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
       mapContainer.current?.removeEventListener('click', handlePopupClick);
       popupRef.current?.remove();
       popupRef.current = null;
+      initialFitDoneRef.current = false;
       if (map.current) {
         map.current.remove();
         map.current = null;
@@ -485,12 +487,13 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
       if (m.getLayer(id)) m.setLayoutProperty(id, 'visibility', vis);
     });
 
-    if (geoConnections.length > 1) {
+    if (!initialFitDoneRef.current && geoConnections.length > 1) {
       const bounds = new maplibregl.LngLatBounds();
       geoConnections.forEach(conn => {
         if (conn.geo_location) bounds.extend([conn.geo_location.longitude, conn.geo_location.latitude]);
       });
       m.fitBounds(bounds, { padding: 60, maxZoom: 14, duration: 0 });
+      initialFitDoneRef.current = true;
     }
   }, [mapLoaded, positionedConnections, geoConnections, layers.myNetwork]);
 

--- a/components/dashboard/ConnectionMap.tsx
+++ b/components/dashboard/ConnectionMap.tsx
@@ -12,6 +12,7 @@ import {
   type MapLayerToggles,
   type MapBeaconRecord,
   beaconGeoJsonFeatures,
+  isSafeBeaconUri,
   parseMapBeacon,
 } from '@/lib/map/mapBeacons';
 
@@ -290,7 +291,8 @@ export default function ConnectionMap({ connections, onConnectionClick }: Connec
       if (!f) return;
       const title = escapeHtml(String(f.properties?.title ?? 'Beacon'));
       const typ = escapeHtml(String(f.properties?.beacon_type ?? ''));
-      const spotify = typeof f.properties?.spotify === 'string' ? f.properties.spotify : '';
+      const spotifyRaw = typeof f.properties?.spotify === 'string' ? f.properties.spotify : '';
+      const spotify = spotifyRaw && isSafeBeaconUri(spotifyRaw) ? spotifyRaw : '';
       const open = spotify
         ? `<a href="${escapeHtml(spotify)}" target="_blank" rel="noreferrer" style="display:inline-block;margin-top:10px;color:#67e8f9;font-size:12px;">Open in Spotify →</a>`
         : '';

--- a/components/insights/BusinessInsightsShell.tsx
+++ b/components/insights/BusinessInsightsShell.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from "react";
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { useAuth } from "@/lib/AuthContext";
 import {
@@ -23,6 +23,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { useInsightsDemo } from "@/components/insights/InsightsDemoContext";
+import VenueBroadcastingModule from "@/components/insights/VenueBroadcastingModule";
 
 const navItems = [
   { href: "/insights", label: "Overview", icon: LayoutDashboard, exact: true },
@@ -74,6 +75,8 @@ export default function BusinessInsightsShell({
 }: BusinessInsightsShellProps) {
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const insightsVenueId = searchParams.get("venue_id")?.trim() || null;
   const { user, signOut } = useAuth();
   const { demoMode, setDemoMode } = useInsightsDemo();
   const [isLive] = useState(true);
@@ -271,7 +274,12 @@ export default function BusinessInsightsShell({
 
       {/* Page content */}
       <main className="relative p-4 md:p-6 lg:p-8">
-        <div className="max-w-[1800px] mx-auto">{children}</div>
+        <div className="max-w-[1800px] mx-auto space-y-6">
+          {pathname === "/insights/vibe-radar" && insightsVenueId ? (
+            <VenueBroadcastingModule venueId={insightsVenueId} />
+          ) : null}
+          {children}
+        </div>
       </main>
     </div>
   );

--- a/components/insights/VenueBroadcastingModule.tsx
+++ b/components/insights/VenueBroadcastingModule.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Music2, Loader2 } from "lucide-react";
+import { GlassPanel } from "@/components/insights/GlassPanel";
+import { postInsightsApiJson } from "@/lib/insights/fetchInsightsApi";
+
+type Props = {
+  venueId: string | null;
+};
+
+/**
+ * Verified venues: drop an official soundtrack pin at venue coordinates (Spotify playlist URI).
+ */
+export default function VenueBroadcastingModule({ venueId }: Props) {
+  const [uri, setUri] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const onSubmit = useCallback(async () => {
+    setMessage(null);
+    if (!venueId) {
+      setMessage("Select a venue (venue_id) to broadcast.");
+      return;
+    }
+    const trimmed = uri.trim();
+    if (!trimmed.startsWith("spotify:playlist:")) {
+      setMessage("Use a Spotify playlist URI like spotify:playlist:37i9dQZF1DXcBWIGoYBM5M");
+      return;
+    }
+    setBusy(true);
+    try {
+      await postInsightsApiJson<{ beacon: unknown }>(
+        `/api/insights/${encodeURIComponent(venueId)}/beacons`,
+        { spotify_playlist_uri: trimmed },
+      );
+      setMessage("Official soundtrack published on the venue map pin.");
+      setUri("");
+    } catch (e) {
+      const err = e as { info?: { error?: string } };
+      setMessage(typeof err?.info === "object" && err.info && "error" in err.info ? String(err.info.error) : "Could not publish soundtrack");
+    } finally {
+      setBusy(false);
+    }
+  }, [uri, venueId]);
+
+  if (!venueId) {
+    return null;
+  }
+
+  return (
+    <GlassPanel className="p-5" hover={false} glow="blue">
+      <div className="flex items-start gap-3">
+        <div className="p-2 rounded-xl bg-cyan-500/15 border border-cyan-400/25 shrink-0">
+          <Music2 className="w-5 h-5 text-cyan-300" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold text-white">Venue broadcasting</h3>
+            <p className="text-xs text-zinc-500 mt-1">
+              Verified venues only: place an official soundtrack on your venue coordinates for the local map.
+            </p>
+          </div>
+          <input
+            type="text"
+            value={uri}
+            onChange={(e) => setUri(e.target.value)}
+            placeholder="spotify:playlist:…"
+            className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+            disabled={busy}
+            autoComplete="off"
+          />
+          <button
+            type="button"
+            onClick={() => void onSubmit()}
+            disabled={busy}
+            className="inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold text-white bg-cyan-600/80 hover:bg-cyan-600 border border-cyan-400/30 disabled:opacity-50"
+          >
+            {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            Publish official soundtrack
+          </button>
+          {message ? <p className="text-xs text-zinc-400">{message}</p> : null}
+        </div>
+      </div>
+    </GlassPanel>
+  );
+}

--- a/components/insights/VibeRadarClient.tsx
+++ b/components/insights/VibeRadarClient.tsx
@@ -17,6 +17,7 @@ import {
   type VibeRadarApiResponse,
   type VenuePopUpHubBeacon,
 } from "@/lib/insights/vibeRadar";
+import type { MapBeaconRecord } from "@/lib/map/mapBeacons";
 
 const containerVariants = {
   hidden: { opacity: 0 },
@@ -54,6 +55,8 @@ export default function VibeRadarClient({
     },
   );
 
+  const venueForBeacons =
+    (venueQuery && venueQuery.trim()) || data?.venueId || initialPayload?.venueId || null;
   const view = useMemo((): VibeRadarApiResponse | null => {
     if (!data) return null;
     if (!demoMode) return data;
@@ -67,8 +70,20 @@ export default function VibeRadarClient({
       venueId: data.venueId,
       status: data.status === "no_venue" ? "no_venue" : demo.status,
       message: data.message,
+      trendingVibes: data.trendingVibes?.length ? data.trendingVibes : demo.trendingVibes,
     };
   }, [data, demoMode]);
+
+  const beaconsListUrl =
+    user && venueForBeacons && view && view.status !== "no_venue"
+      ? `/api/insights/${encodeURIComponent(venueForBeacons)}/beacons`
+      : null;
+  const { data: venueBeaconsPayload } = useSWR<{ beacons: MapBeaconRecord[] }>(
+    beaconsListUrl,
+    fetchInsightsApiJson,
+    { revalidateOnFocus: false },
+  );
+  const venueBeacons = venueBeaconsPayload?.beacons ?? [];
 
   const effectiveVenueId = view?.venueId ?? null;
   const demoLocked = demoMode && (!!view && view.status === "no_venue");
@@ -88,6 +103,7 @@ export default function VibeRadarClient({
   const clusters = view?.clusters ?? [];
   const categoryTotals = view?.categoryTotals ?? [];
   const venueCenter = view?.venueCenter ?? { lat: null, lng: null };
+  const trendingVibes = view?.trendingVibes ?? [];
 
   const showSkeleton = !view && (isLoading || isValidating);
 
@@ -133,8 +149,8 @@ export default function VibeRadarClient({
         </motion.p>
       ) : null}
 
-      <motion.div variants={itemVariants} className="grid grid-cols-1 xl:grid-cols-3 gap-4 md:gap-6">
-        <GlassPanel className="p-5 xl:col-span-1" hover={false} glow="purple">
+      <motion.div variants={itemVariants} className="grid grid-cols-1 xl:grid-cols-12 gap-4 md:gap-6">
+        <GlassPanel className="p-5 xl:col-span-3" hover={false} glow="purple">
           <h3 className="text-sm font-semibold text-white mb-1">Signal strength</h3>
           <p className="text-xs text-zinc-500 mb-4">
             Volume drives blob size; hue reflects intent category.
@@ -160,7 +176,7 @@ export default function VibeRadarClient({
           )}
         </GlassPanel>
 
-        <div className="xl:col-span-2 min-h-[420px]">
+        <div className="xl:col-span-6 min-h-[420px] order-3 xl:order-none">
           {showSkeleton ? (
             <div className="h-[min(56vh,620px)] rounded-2xl border border-white/10 bg-white/5 animate-pulse" />
           ) : (
@@ -168,9 +184,34 @@ export default function VibeRadarClient({
               clusters={clusters}
               venueCenter={venueCenter}
               showBeaconPulse={beaconPulse}
+              venueBeacons={venueBeacons}
             />
           )}
         </div>
+
+        <GlassPanel className="p-5 xl:col-span-3 order-2 xl:order-none" hover={false} glow="blue">
+          <h3 className="text-sm font-semibold text-white mb-1">Trending vibes around you</h3>
+          <p className="text-xs text-zinc-500 mb-4">
+            Beacon density by type within the same radius as intent clusters.
+          </p>
+          {showSkeleton ? (
+            <div className="h-28 rounded-xl bg-white/5 animate-pulse" />
+          ) : trendingVibes.length === 0 ? (
+            <p className="text-sm text-zinc-500">No active community map pins in range yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {trendingVibes.map((t) => (
+                <li
+                  key={t.beacon_type}
+                  className="flex justify-between text-sm border-b border-white/5 pb-2 last:border-0"
+                >
+                  <span className="text-zinc-200 capitalize">{t.beacon_type.replace(/_/g, " ")}</span>
+                  <span className="text-cyan-400/90 tabular-nums font-medium">{t.count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </GlassPanel>
       </motion.div>
 
       <BeaconDeployModal

--- a/components/insights/VibeRadarMap.tsx
+++ b/components/insights/VibeRadarMap.tsx
@@ -12,6 +12,7 @@ import {
   type MapBeaconRecord,
   type MapLayerToggles,
   beaconGeoJsonFeatures,
+  isSafeBeaconUri,
 } from "@/lib/map/mapBeacons";
 
 const DEFAULT_CENTER: [number, number] = [-122.3321, 47.6062];
@@ -110,7 +111,8 @@ export default function VibeRadarMap({
       if (!f) return;
       const title = escapeMapHtml(String(f.properties?.title ?? "Beacon"));
       const typ = escapeMapHtml(String(f.properties?.beacon_type ?? ""));
-      const spotify = typeof f.properties?.spotify === "string" ? f.properties.spotify : "";
+      const spotifyRaw = typeof f.properties?.spotify === "string" ? f.properties.spotify : "";
+      const spotify = spotifyRaw && isSafeBeaconUri(spotifyRaw) ? spotifyRaw : "";
       const open = spotify
         ? `<a href="${escapeMapHtml(spotify)}" target="_blank" rel="noreferrer" style="display:inline-block;margin-top:10px;color:#67e8f9;font-size:12px;">Open in Spotify →</a>`
         : "";

--- a/components/insights/VibeRadarMap.tsx
+++ b/components/insights/VibeRadarMap.tsx
@@ -1,31 +1,55 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { motion, AnimatePresence } from "framer-motion";
-import { Loader2, MapPin } from "lucide-react";
+import { Loader2, MapPin, Layers } from "lucide-react";
 import type { VibeRadarCluster } from "@/lib/insights/vibeRadar";
 import { vibeCategoryColor } from "@/lib/insights/vibeRadar";
+import {
+  DEFAULT_MAP_LAYER_TOGGLES,
+  type MapBeaconRecord,
+  type MapLayerToggles,
+  beaconGeoJsonFeatures,
+} from "@/lib/map/mapBeacons";
 
 const DEFAULT_CENTER: [number, number] = [-122.3321, 47.6062];
 
-function buildGeoJson(clusters: VibeRadarCluster[]) {
-  return {
-    type: "FeatureCollection" as const,
-    features: clusters.map((c) => ({
-      type: "Feature" as const,
-      geometry: {
-        type: "Point" as const,
-        coordinates: [c.approx_lng, c.approx_lat],
-      },
-      properties: {
-        count: c.count,
-        category: c.category,
-        color: vibeCategoryColor(c.category),
-      },
-    })),
-  };
+const SRC_INTENTS = "vr-intents-geo";
+const SRC_OFFICIAL = "vr-beacons-official";
+const SRC_COMMUNITY = "vr-beacons-community";
+const SRC_HAZARDS = "vr-beacons-hazards";
+
+const CLUSTER_MAX_ZOOM = 13;
+const CLUSTER_RADIUS = 48;
+
+function emptyFc(): GeoJSON.FeatureCollection {
+  return { type: "FeatureCollection", features: [] };
+}
+
+function intentFeatures(clusters: VibeRadarCluster[]): GeoJSON.Feature[] {
+  return clusters.map((c) => ({
+    type: "Feature" as const,
+    geometry: {
+      type: "Point" as const,
+      coordinates: [c.approx_lng, c.approx_lat],
+    },
+    properties: {
+      count: c.count,
+      category: c.category,
+      color: vibeCategoryColor(c.category),
+    },
+  }));
+}
+
+/** Minimal HTML escape for map popups (labels from beacon metadata). */
+function escapeMapHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 export interface VibeRadarMapProps {
@@ -33,23 +57,103 @@ export interface VibeRadarMapProps {
   venueCenter: { lat: number | null; lng: number | null };
   /** Pulse a beacon marker at the venue after deploy. */
   showBeaconPulse?: boolean;
+  /** Venue-scoped map beacons (managers); shown on separate clustered layers. */
+  venueBeacons?: MapBeaconRecord[];
 }
 
 /**
- * MapLibre map: soft “hex-like” blobs from aggregated intent cells; volume → size/opacity.
+ * MapLibre map: intent clusters + optional venue beacon layers (native GeoJSON clustering).
  */
 export default function VibeRadarMap({
   clusters,
   venueCenter,
   showBeaconPulse = false,
+  venueBeacons = [],
 }: VibeRadarMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<maplibregl.Map | null>(null);
   const beaconMarkerRef = useRef<maplibregl.Marker | null>(null);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [mapError, setMapError] = useState<string | null>(null);
+  const [layers, setLayers] = useState<MapLayerToggles>(() => ({ ...DEFAULT_MAP_LAYER_TOGGLES }));
 
-  // Init map
+  const initCenterRef = useRef<[number, number] | null>(null);
+  if (initCenterRef.current === null) {
+    if (
+      venueCenter.lat != null &&
+      venueCenter.lng != null &&
+      Number.isFinite(venueCenter.lat) &&
+      Number.isFinite(venueCenter.lng)
+    ) {
+      initCenterRef.current = [venueCenter.lng, venueCenter.lat];
+    } else {
+      initCenterRef.current = DEFAULT_CENTER;
+    }
+  }
+
+  const attachInteractions = useCallback((map: maplibregl.Map) => {
+    const expandCluster = (sourceId: string) => (e: maplibregl.MapLayerMouseEvent) => {
+      const f = e.features?.[0];
+      if (!f || f.geometry.type !== "Point") return;
+      const clusId = f.properties?.cluster_id;
+      const src = map.getSource(sourceId) as maplibregl.GeoJSONSource | undefined;
+      if (clusId == null || !src?.getClusterExpansionZoom) return;
+      void src.getClusterExpansionZoom(clusId as number).then((z) => {
+        const coords = (f.geometry as GeoJSON.Point).coordinates as [number, number];
+        map.easeTo({ center: coords, zoom: z + 0.35, duration: 420 });
+      });
+    };
+
+    const onBeaconPoint = (e: maplibregl.MapLayerMouseEvent) => {
+      const f = e.features?.[0];
+      if (!f) return;
+      const title = escapeMapHtml(String(f.properties?.title ?? "Beacon"));
+      const typ = escapeMapHtml(String(f.properties?.beacon_type ?? ""));
+      const spotify = typeof f.properties?.spotify === "string" ? f.properties.spotify : "";
+      const open = spotify
+        ? `<a href="${escapeMapHtml(spotify)}" target="_blank" rel="noreferrer" style="display:inline-block;margin-top:10px;color:#67e8f9;font-size:12px;">Open in Spotify →</a>`
+        : "";
+      popupRef.current?.remove();
+      const html = `<div style="color:#fff;background:#18181b;padding:12px 14px;border-radius:12px;border:1px solid #27272a;max-width:240px;">
+        <div style="font-weight:600;color:#e4e4e7;margin-bottom:4px;">${title}</div>
+        <div style="font-size:11px;color:#a1a1aa;">${typ}</div>
+        ${open}
+      </div>`;
+      popupRef.current = new maplibregl.Popup({ offset: 14, closeButton: true, maxWidth: "260px" })
+        .setLngLat(e.lngLat)
+        .setHTML(html)
+        .addTo(map);
+    };
+
+    map.on("click", "vr-intent-clusters", expandCluster(SRC_INTENTS));
+    map.on("click", "vr-official-beacon-clusters", expandCluster(SRC_OFFICIAL));
+    map.on("click", "vr-community-beacon-clusters", expandCluster(SRC_COMMUNITY));
+    map.on("click", "vr-hazard-beacon-clusters", expandCluster(SRC_HAZARDS));
+    map.on("click", "vr-official-beacon-unclustered", onBeaconPoint);
+    map.on("click", "vr-community-beacon-unclustered", onBeaconPoint);
+    map.on("click", "vr-hazard-beacon-unclustered", onBeaconPoint);
+
+    const hoverIds = [
+      "vr-intent-clusters",
+      "vr-intent-unclustered",
+      "vr-official-beacon-clusters",
+      "vr-official-beacon-unclustered",
+      "vr-community-beacon-clusters",
+      "vr-community-beacon-unclustered",
+      "vr-hazard-beacon-clusters",
+      "vr-hazard-beacon-unclustered",
+    ];
+    hoverIds.forEach((id) => {
+      map.on("mouseenter", id, () => {
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", id, () => {
+        map.getCanvas().style.cursor = "";
+      });
+    });
+  }, []);
+
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
 
@@ -57,7 +161,7 @@ export default function VibeRadarMap({
       const map = new maplibregl.Map({
         container: containerRef.current,
         style: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
-        center: DEFAULT_CENTER,
+        center: initCenterRef.current ?? DEFAULT_CENTER,
         zoom: 12.2,
         attributionControl: false,
       });
@@ -65,60 +169,112 @@ export default function VibeRadarMap({
       map.addControl(new maplibregl.NavigationControl(), "top-right");
 
       map.on("load", () => {
-        map.addSource("vibe-intents", {
+        map.addSource(SRC_INTENTS, {
           type: "geojson",
-          data: buildGeoJson(clusters),
+          data: emptyFc(),
+          cluster: true,
+          clusterMaxZoom: CLUSTER_MAX_ZOOM,
+          clusterRadius: CLUSTER_RADIUS,
         });
 
         map.addLayer({
-          id: "vibe-intents-glow",
+          id: "vr-intent-clusters",
           type: "circle",
-          source: "vibe-intents",
+          source: SRC_INTENTS,
+          filter: ["has", "point_count"],
           paint: {
-            "circle-radius": [
-              "interpolate",
-              ["linear"],
-              ["get", "count"],
-              1,
-              18,
-              200,
-              64,
-            ],
-            "circle-color": ["get", "color"],
-            "circle-opacity": [
-              "interpolate",
-              ["linear"],
-              ["get", "count"],
-              1,
-              0.25,
-              200,
-              0.72,
-            ],
-            "circle-blur": 0.85,
+            "circle-color": "#6520c0",
+            "circle-radius": ["step", ["get", "point_count"], 18, 8, 22, 20, 28],
+            "circle-opacity": 0.88,
+            "circle-stroke-width": 2,
+            "circle-stroke-color": "rgba(255,255,255,0.9)",
           },
         });
-
         map.addLayer({
-          id: "vibe-intents-core",
+          id: "vr-intent-cluster-count",
+          type: "symbol",
+          source: SRC_INTENTS,
+          filter: ["has", "point_count"],
+          layout: {
+            "text-field": ["get", "point_count_abbreviated"],
+            "text-size": 11,
+          },
+          paint: { "text-color": "#ffffff" },
+        });
+        map.addLayer({
+          id: "vr-intent-unclustered",
           type: "circle",
-          source: "vibe-intents",
+          source: SRC_INTENTS,
+          filter: ["!", ["has", "point_count"]],
           paint: {
+            "circle-color": ["get", "color"],
             "circle-radius": [
               "interpolate",
               ["linear"],
               ["get", "count"],
               1,
-              5,
+              8,
               200,
-              14,
+              22,
             ],
-            "circle-color": ["get", "color"],
-            "circle-opacity": 0.95,
+            "circle-opacity": 0.92,
             "circle-stroke-width": 1.5,
             "circle-stroke-color": "rgba(255,255,255,0.35)",
           },
         });
 
+        const addBeaconStack = (sourceId: string, prefix: string, fallback: string) => {
+          map.addSource(sourceId, {
+            type: "geojson",
+            data: emptyFc(),
+            cluster: true,
+            clusterMaxZoom: CLUSTER_MAX_ZOOM,
+            clusterRadius: CLUSTER_RADIUS + 4,
+          });
+          map.addLayer({
+            id: `${prefix}-clusters`,
+            type: "circle",
+            source: sourceId,
+            filter: ["has", "point_count"],
+            paint: {
+              "circle-color": fallback,
+              "circle-radius": ["step", ["get", "point_count"], 16, 6, 20, 16, 24],
+              "circle-opacity": 0.88,
+              "circle-stroke-width": 2,
+              "circle-stroke-color": "rgba(255,255,255,0.85)",
+            },
+          });
+          map.addLayer({
+            id: `${prefix}-cluster-count`,
+            type: "symbol",
+            source: sourceId,
+            filter: ["has", "point_count"],
+            layout: {
+              "text-field": ["get", "point_count_abbreviated"],
+              "text-size": 10,
+            },
+            paint: { "text-color": "#0a0a0a" },
+          });
+          map.addLayer({
+            id: `${prefix}-unclustered`,
+            type: "circle",
+            source: sourceId,
+            filter: ["!", ["has", "point_count"]],
+            paint: {
+              "circle-color": ["get", "tint"],
+              "circle-radius": 10,
+              "circle-opacity": 0.95,
+              "circle-stroke-width": 2,
+              "circle-stroke-color": "#ffffff",
+            },
+          });
+        };
+
+        addBeaconStack(SRC_OFFICIAL, "vr-official-beacon", "#22d3ee");
+        addBeaconStack(SRC_COMMUNITY, "vr-community-beacon", "#34d399");
+        addBeaconStack(SRC_HAZARDS, "vr-hazard-beacon", "#f97316");
+
+        attachInteractions(map);
         setMapLoaded(true);
         map.resize();
       });
@@ -135,15 +291,16 @@ export default function VibeRadarMap({
     }
 
     return () => {
+      popupRef.current?.remove();
+      popupRef.current = null;
       beaconMarkerRef.current?.remove();
       beaconMarkerRef.current = null;
       mapRef.current?.remove();
       mapRef.current = null;
       setMapLoaded(false);
     };
-  }, []);
+  }, [attachInteractions]);
 
-  // Venue anchor when there are no cells yet
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !mapLoaded) return;
@@ -158,14 +315,11 @@ export default function VibeRadarMap({
     }
   }, [mapLoaded, clusters.length, venueCenter.lat, venueCenter.lng]);
 
-  // Push cluster updates
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !mapLoaded) return;
-    const src = map.getSource("vibe-intents") as maplibregl.GeoJSONSource | undefined;
-    if (src) {
-      src.setData(buildGeoJson(clusters));
-    }
+    const src = map.getSource(SRC_INTENTS) as maplibregl.GeoJSONSource | undefined;
+    src?.setData({ type: "FeatureCollection", features: intentFeatures(clusters) });
 
     if (clusters.length > 0) {
       const bounds = new maplibregl.LngLatBounds();
@@ -173,6 +327,38 @@ export default function VibeRadarMap({
       map.fitBounds(bounds, { padding: 72, maxZoom: 13.5, duration: 600 });
     }
   }, [clusters, mapLoaded]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapLoaded) return;
+    const setData = (id: string, feats: GeoJSON.Feature[]) => {
+      (map.getSource(id) as maplibregl.GeoJSONSource | undefined)?.setData({
+        type: "FeatureCollection",
+        features: feats,
+      });
+    };
+    setData(SRC_OFFICIAL, beaconGeoJsonFeatures(venueBeacons, "official"));
+    setData(SRC_COMMUNITY, beaconGeoJsonFeatures(venueBeacons, "community"));
+    setData(SRC_HAZARDS, beaconGeoJsonFeatures(venueBeacons, "hazard"));
+
+    const vis = (on: boolean) => (on ? "visible" : "none");
+    ["vr-intent-clusters", "vr-intent-cluster-count", "vr-intent-unclustered"].forEach((lid) => {
+      if (map.getLayer(lid)) map.setLayoutProperty(lid, "visibility", vis(layers.myNetwork));
+    });
+    ["vr-official-beacon-clusters", "vr-official-beacon-cluster-count", "vr-official-beacon-unclustered"].forEach(
+      (lid) => {
+        if (map.getLayer(lid)) map.setLayoutProperty(lid, "visibility", vis(layers.officialSoundtracks));
+      },
+    );
+    ["vr-community-beacon-clusters", "vr-community-beacon-cluster-count", "vr-community-beacon-unclustered"].forEach(
+      (lid) => {
+        if (map.getLayer(lid)) map.setLayoutProperty(lid, "visibility", vis(layers.communityBeacons));
+      },
+    );
+    ["vr-hazard-beacon-clusters", "vr-hazard-beacon-cluster-count", "vr-hazard-beacon-unclustered"].forEach((lid) => {
+      if (map.getLayer(lid)) map.setLayoutProperty(lid, "visibility", vis(layers.hazards));
+    });
+  }, [mapLoaded, venueBeacons, layers.myNetwork, layers.officialSoundtracks, layers.communityBeacons, layers.hazards]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -233,6 +419,10 @@ export default function VibeRadarMap({
     };
   }, [mapLoaded]);
 
+  const toggle = (key: keyof MapLayerToggles) => {
+    setLayers((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
   if (mapError) {
     return (
       <div className="rounded-2xl border border-white/10 bg-white/5 backdrop-blur-md p-12 text-center">
@@ -263,14 +453,49 @@ export default function VibeRadarMap({
 
       <div ref={containerRef} className="absolute inset-0" />
 
+      {mapLoaded && (
+        <div className="absolute top-3 left-3 z-[6] max-w-[220px] rounded-2xl border border-white/10 bg-zinc-950/70 backdrop-blur-xl shadow-lg shadow-black/40 p-3 text-xs text-zinc-200">
+          <div className="flex items-center gap-2 mb-2 font-semibold text-white">
+            <Layers className="w-3.5 h-3.5 text-[#8338EC]" />
+            Map layers
+          </div>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input type="checkbox" className="accent-[#8338EC]" checked={layers.myNetwork} onChange={() => toggle("myNetwork")} />
+            Availability intents
+          </label>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="accent-[#8338EC]"
+              checked={layers.officialSoundtracks}
+              onChange={() => toggle("officialSoundtracks")}
+            />
+            Official Soundtracks
+          </label>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="accent-[#8338EC]"
+              checked={layers.communityBeacons}
+              onChange={() => toggle("communityBeacons")}
+            />
+            Community Beacons
+          </label>
+          <label className="flex items-center gap-2 py-1 cursor-pointer select-none">
+            <input type="checkbox" className="accent-[#8338EC]" checked={layers.hazards} onChange={() => toggle("hazards")} />
+            Hazards
+          </label>
+        </div>
+      )}
+
       {mapLoaded && clusters.length === 0 && (
         <motion.div
           initial={{ opacity: 0, y: 6 }}
           animate={{ opacity: 1, y: 0 }}
           className="absolute bottom-4 left-4 right-4 sm:right-auto max-w-md z-[5] rounded-xl border border-white/10 bg-zinc-950/85 backdrop-blur-md px-4 py-3 text-sm text-zinc-400"
         >
-          No aggregated cells in range yet. When guests share coarse area buckets with active
-          intents, clusters appear here — never individual identities.
+          No aggregated cells in range yet. When guests share coarse area buckets with active intents,
+          clusters appear here — never individual identities.
         </motion.div>
       )}
     </div>

--- a/lib/insights/vibeRadar.ts
+++ b/lib/insights/vibeRadar.ts
@@ -15,6 +15,11 @@ export type VibeRadarCategoryTotal = {
   count: number;
 };
 
+export type VibeRadarBeaconTrend = {
+  beacon_type: string;
+  count: number;
+};
+
 export type VibeRadarApiResponse = {
   clusters: VibeRadarCluster[];
   categoryTotals: VibeRadarCategoryTotal[];
@@ -23,6 +28,8 @@ export type VibeRadarApiResponse = {
   status: string;
   venueId?: string;
   message?: string;
+  /** Active map_beacons by type within the same radius as intent clusters (managers only). */
+  trendingVibes?: VibeRadarBeaconTrend[];
 };
 
 export type VenuePopUpHubBeacon = {
@@ -59,10 +66,19 @@ function parseCategoryTotal(row: unknown): VibeRadarCategoryTotal | null {
   return { category, count };
 }
 
+function parseTrendingVibe(row: unknown): VibeRadarBeaconTrend | null {
+  if (!row || typeof row !== "object") return null;
+  const o = row as Record<string, unknown>;
+  const beacon_type = typeof o.beacon_type === "string" ? o.beacon_type : null;
+  const count = typeof o.count === "number" && Number.isFinite(o.count) ? o.count : null;
+  if (beacon_type == null || count == null) return null;
+  return { beacon_type, count };
+}
+
 /** Normalize JSON from `insights_vibe_radar_data` RPC. */
 export function parseVibeRadarRpcPayload(
   raw: unknown,
-): Omit<VibeRadarApiResponse, "venueId" | "message"> {
+): Omit<VibeRadarApiResponse, "venueId" | "message" | "trendingVibes"> {
   const empty = {
     clusters: [] as VibeRadarCluster[],
     categoryTotals: [] as VibeRadarCategoryTotal[],
@@ -99,6 +115,14 @@ export function parseVibeRadarRpcPayload(
     radiusMeters,
     status,
   };
+}
+
+/** Normalize JSON from `insights_vibe_radar_beacon_density` RPC. */
+export function parseVibeRadarBeaconDensityRpc(raw: unknown): VibeRadarBeaconTrend[] {
+  if (!raw || typeof raw !== "object") return [];
+  const o = raw as Record<string, unknown>;
+  const arr = Array.isArray(o.trending) ? o.trending : [];
+  return arr.map(parseTrendingVibe).filter((x): x is VibeRadarBeaconTrend => x != null);
 }
 
 const DEMO_CENTER = { lat: 47.6062, lng: -122.3321 };
@@ -165,5 +189,10 @@ export function demoVibeRadarResponse(): Omit<VibeRadarApiResponse, "venueId"> {
     venueCenter: DEMO_CENTER,
     radiusMeters: 160.934,
     status: "ok",
+    trendingVibes: [
+      { beacon_type: "soundtrack", count: 24 },
+      { beacon_type: "recreation", count: 11 },
+      { beacon_type: "study", count: 9 },
+    ],
   };
 }

--- a/lib/map/mapBeacons.ts
+++ b/lib/map/mapBeacons.ts
@@ -96,6 +96,11 @@ export function beaconLayerGroup(
   return "community";
 }
 
+/** Only allow known-safe URI schemes in beacon popup links. */
+export function isSafeBeaconUri(uri: string): boolean {
+  return /^(spotify:|https?:\/\/)/i.test(uri);
+}
+
 export function beaconTint(beaconType: MapBeaconType, group: ReturnType<typeof beaconLayerGroup>): string {
   if (group === "hazard") return "#f97316";
   if (group === "official") return "#22d3ee";
@@ -123,7 +128,8 @@ export function beaconGeoJsonFeatures(
         tint: beaconTint(b.beacon_type, group),
         title: String((b.metadata as { label?: unknown }).label ?? b.beacon_type),
         spotify:
-          typeof (b.metadata as { spotify_playlist_uri?: unknown }).spotify_playlist_uri === "string"
+          typeof (b.metadata as { spotify_playlist_uri?: unknown }).spotify_playlist_uri === "string" &&
+          isSafeBeaconUri((b.metadata as { spotify_playlist_uri: string }).spotify_playlist_uri)
             ? (b.metadata as { spotify_playlist_uri: string }).spotify_playlist_uri
             : "",
       },

--- a/lib/map/mapBeacons.ts
+++ b/lib/map/mapBeacons.ts
@@ -1,0 +1,131 @@
+/**
+ * Map beacon types and helpers (PostGIS rows exposed as JSON from RPC/API).
+ */
+
+export const MAP_BEACON_TYPES = [
+  "soundtrack",
+  "hazard_utility",
+  "swag",
+  "capacity",
+  "recreation",
+  "transit",
+  "sos",
+  "study",
+  "hobby",
+  "scavenger",
+] as const;
+
+export type MapBeaconType = (typeof MAP_BEACON_TYPES)[number];
+
+export type MapBeaconRecord = {
+  id: string;
+  creator_id: string;
+  venue_id: string | null;
+  beacon_type: MapBeaconType;
+  lat: number;
+  lng: number;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  expires_at: string;
+};
+
+export type MapLayerToggles = {
+  myNetwork: boolean;
+  officialSoundtracks: boolean;
+  communityBeacons: boolean;
+  hazards: boolean;
+};
+
+export const DEFAULT_MAP_LAYER_TOGGLES: MapLayerToggles = {
+  myNetwork: true,
+  officialSoundtracks: true,
+  communityBeacons: false,
+  hazards: false,
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+export function parseMapBeacon(row: unknown): MapBeaconRecord | null {
+  if (!isRecord(row)) return null;
+  const id = typeof row.id === "string" ? row.id : null;
+  const creator_id = typeof row.creator_id === "string" ? row.creator_id : null;
+  const beacon_type = typeof row.beacon_type === "string" ? row.beacon_type : null;
+  const lat = typeof row.lat === "number" && Number.isFinite(row.lat) ? row.lat : null;
+  const lng = typeof row.lng === "number" && Number.isFinite(row.lng) ? row.lng : null;
+  const created_at = typeof row.created_at === "string" ? row.created_at : null;
+  const expires_at = typeof row.expires_at === "string" ? row.expires_at : null;
+  const metaRaw = row.metadata;
+  const metadata = isRecord(metaRaw) ? metaRaw : {};
+
+  if (
+    id == null ||
+    creator_id == null ||
+    beacon_type == null ||
+    lat == null ||
+    lng == null ||
+    created_at == null ||
+    expires_at == null
+  ) {
+    return null;
+  }
+
+  if (!MAP_BEACON_TYPES.includes(beacon_type as MapBeaconType)) return null;
+
+  return {
+    id,
+    creator_id,
+    venue_id: typeof row.venue_id === "string" ? row.venue_id : null,
+    beacon_type: beacon_type as MapBeaconType,
+    lat,
+    lng,
+    metadata,
+    created_at,
+    expires_at,
+  };
+}
+
+export function beaconLayerGroup(
+  b: Pick<MapBeaconRecord, "beacon_type" | "metadata">,
+): "official" | "community" | "hazard" {
+  if (b.beacon_type === "hazard_utility") return "hazard";
+  const official =
+    b.beacon_type === "soundtrack" && Boolean((b.metadata as { is_official?: unknown }).is_official);
+  if (official) return "official";
+  return "community";
+}
+
+export function beaconTint(beaconType: MapBeaconType, group: ReturnType<typeof beaconLayerGroup>): string {
+  if (group === "hazard") return "#f97316";
+  if (group === "official") return "#22d3ee";
+  if (beaconType === "sos") return "#ef4444";
+  if (beaconType === "soundtrack") return "#a78bfa";
+  return "#34d399";
+}
+
+/** GeoJSON point features for MapLibre (clustering layers read `tint`, `title`, `spotify`). */
+export function beaconGeoJsonFeatures(
+  beacons: MapBeaconRecord[],
+  group: "official" | "community" | "hazard",
+): GeoJSON.Feature[] {
+  return beacons
+    .filter((b) => beaconLayerGroup(b) === group)
+    .map((b) => ({
+      type: "Feature" as const,
+      geometry: {
+        type: "Point" as const,
+        coordinates: [b.lng, b.lat],
+      },
+      properties: {
+        id: b.id,
+        beacon_type: b.beacon_type,
+        tint: beaconTint(b.beacon_type, group),
+        title: String((b.metadata as { label?: unknown }).label ?? b.beacon_type),
+        spotify:
+          typeof (b.metadata as { spotify_playlist_uri?: unknown }).spotify_playlist_uri === "string"
+            ? (b.metadata as { spotify_playlist_uri: string }).spotify_playlist_uri
+            : "",
+      },
+    }));
+}

--- a/supabase/functions/fetch-local-beacons/index.ts
+++ b/supabase/functions/fetch-local-beacons/index.ts
@@ -1,0 +1,109 @@
+/**
+ * Edge Function: fetch-local-beacons
+ *
+ * POST JSON { lat: number, lng: number, radius_meters?: number }
+ * Authorization: Bearer <user JWT>
+ *
+ * Returns active map_beacons within radius using PostGIS ST_DWithin (via RPC).
+ */
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+
+const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+function finiteNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const jwt = authHeader.replace(/^Bearer\s+/i, '').trim();
+  if (!jwt) {
+    return new Response(JSON.stringify({ error: 'Missing Authorization bearer token' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  if (!supabaseUrl || !anonKey) {
+    return new Response(JSON.stringify({ error: 'Server misconfigured' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const userClient = createClient(supabaseUrl, anonKey, {
+    auth: { persistSession: false },
+    global: { headers: { Authorization: `Bearer ${jwt}` } },
+  });
+
+  const {
+    data: { user },
+    error: userErr,
+  } = await userClient.auth.getUser(jwt);
+  if (userErr || !user?.id) {
+    return new Response(JSON.stringify({ error: 'Invalid session' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  let body: { lat?: unknown; lng?: unknown; radius_meters?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const lat = finiteNumber(body.lat);
+  const lng = finiteNumber(body.lng);
+  const radiusRaw = finiteNumber(body.radius_meters);
+  const radius_m = radiusRaw != null ? Math.min(Math.max(radiusRaw, 100), 50_000) : 5000;
+
+  if (lat == null || lng == null) {
+    return new Response(JSON.stringify({ error: 'lat and lng are required finite numbers' }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { data, error } = await userClient.rpc('fetch_map_beacons_within', {
+    lat,
+    lng,
+    radius_meters: radius_m,
+  });
+
+  if (error) {
+    console.error('fetch_map_beacons_within:', error.message);
+    return new Response(JSON.stringify({ error: 'Failed to load beacons', detail: error.message }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const beacons = data != null && typeof data === 'object' && !Array.isArray(data) && 'beacons' in data
+    ? (data as { beacons: unknown }).beacons
+    : data;
+  const list = Array.isArray(beacons) ? beacons : [];
+  return new Response(JSON.stringify({ beacons: list }), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/migrations/20260501000000_map_beacons.sql
+++ b/supabase/migrations/20260501000000_map_beacons.sql
@@ -1,0 +1,466 @@
+-- Map beacons: local soundtracks + community signals (PostGIS), RLS, proximity fetch RPC,
+-- and hub chat broadcast when recreation/hobby beacons land near an active ephemeral hub.
+
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- ---------------------------------------------------------------------------
+-- 1. Enum + table
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public'
+          AND t.typname = 'map_beacon_type'
+    ) THEN
+        CREATE TYPE public.map_beacon_type AS ENUM (
+            'soundtrack',
+            'hazard_utility',
+            'swag',
+            'capacity',
+            'recreation',
+            'transit',
+            'sos',
+            'study',
+            'hobby',
+            'scavenger'
+        );
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.map_beacons (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid (),
+    creator_id UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    venue_id UUID REFERENCES public.venues (id) ON DELETE SET NULL,
+    beacon_type public.map_beacon_type NOT NULL,
+    location geography (Point, 4326) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '7 days'),
+    CONSTRAINT map_beacons_metadata_object CHECK (jsonb_typeof (metadata) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_map_beacons_expires_at ON public.map_beacons (expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_map_beacons_location_gix ON public.map_beacons USING GIST (location);
+
+CREATE INDEX IF NOT EXISTS idx_map_beacons_creator ON public.map_beacons (creator_id);
+
+CREATE INDEX IF NOT EXISTS idx_map_beacons_venue ON public.map_beacons (venue_id)
+WHERE
+    venue_id IS NOT NULL;
+
+COMMENT ON TABLE public.map_beacons IS
+    'Geospatial beacons: soundtracks (7-day default), community signals, and venue-official pins.';
+
+-- Default expiry: 7 days for soundtracks; other types keep explicit client/server expiry.
+CREATE OR REPLACE FUNCTION public.map_beacons_set_default_expiry ()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.beacon_type = 'soundtrack'::public.map_beacon_type THEN
+        IF NEW.expires_at IS NULL OR NEW.expires_at = NEW.created_at THEN
+            NEW.expires_at := NEW.created_at + interval '7 days';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_map_beacons_default_expiry ON public.map_beacons;
+
+CREATE TRIGGER trg_map_beacons_default_expiry
+    BEFORE INSERT ON public.map_beacons
+    FOR EACH ROW
+    EXECUTE FUNCTION public.map_beacons_set_default_expiry ();
+
+-- ---------------------------------------------------------------------------
+-- 2. RLS
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.map_beacons ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "map_beacons_select_active" ON public.map_beacons;
+
+DROP POLICY IF EXISTS "map_beacons_select_scoped" ON public.map_beacons;
+
+CREATE POLICY "map_beacons_select_scoped"
+    ON public.map_beacons
+    FOR SELECT
+    USING (
+        expires_at > now()
+        AND (
+            creator_id = auth.uid ()
+            OR (
+                venue_id IS NOT NULL
+                AND EXISTS (
+                    SELECT 1
+                    FROM public.venue_managers vm
+                    WHERE
+                        vm.venue_id = map_beacons.venue_id
+                        AND vm.user_id = auth.uid ()
+                )
+            )
+        )
+    );
+
+DROP POLICY IF EXISTS "map_beacons_insert_authenticated" ON public.map_beacons;
+
+CREATE POLICY "map_beacons_insert_authenticated"
+    ON public.map_beacons
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (auth.uid () = creator_id);
+
+DROP POLICY IF EXISTS "map_beacons_delete_own" ON public.map_beacons;
+
+CREATE POLICY "map_beacons_delete_own"
+    ON public.map_beacons
+    FOR DELETE
+    TO authenticated
+    USING (auth.uid () = creator_id);
+
+GRANT SELECT, INSERT, DELETE ON public.map_beacons TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. SECURITY DEFINER: insert system hub message (bypasses hub_messages user_id check)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._insert_hub_system_message (
+    p_hub_id TEXT,
+    p_actor_user_id UUID,
+    p_body TEXT,
+    p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    INSERT INTO public.hub_messages (
+        hub_id,
+        user_id,
+        body,
+        metadata,
+        message_type
+    )
+    VALUES (
+        p_hub_id,
+        p_actor_user_id,
+        p_body,
+        COALESCE(p_metadata, '{}'::jsonb) || jsonb_build_object('is_system', true),
+        'text'
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._insert_hub_system_message (TEXT, UUID, TEXT, JSONB) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public._insert_hub_system_message (TEXT, UUID, TEXT, JSONB) TO postgres;
+
+COMMENT ON FUNCTION public._insert_hub_system_message (TEXT, UUID, TEXT, JSONB) IS
+    'Internal: post a system line to hub chat; p_actor_user_id satisfies hub_messages.user_id FK.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Trigger: recreation/hobby near active hub → system message
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.map_beacons_broadcast_near_hub ()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    hub RECORD;
+
+    v_lat DOUBLE PRECISION;
+
+    v_lng DOUBLE PRECISION;
+BEGIN
+    IF TG_OP <> 'INSERT' THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.beacon_type NOT IN ('recreation'::public.map_beacon_type, 'hobby'::public.map_beacon_type) THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.expires_at <= now() THEN
+        RETURN NEW;
+    END IF;
+
+    v_lat := ST_Y (NEW.location::geometry);
+
+    v_lng := ST_X (NEW.location::geometry);
+
+    FOR hub IN
+        SELECT
+            hv.id,
+            hv.name,
+            hv.radius_meters
+        FROM public.hub_venues hv
+        WHERE
+            ST_DWithin (
+                NEW.location,
+                ST_SetSRID (ST_MakePoint (hv.geofence_long, hv.geofence_lat), 4326)::geography,
+                hv.radius_meters
+            )
+    LOOP
+        PERFORM public._insert_hub_system_message (
+            hub.id,
+            NEW.creator_id,
+            format(
+                'A nearby %s beacon was shared in the community map.',
+                NEW.beacon_type
+            ),
+            jsonb_build_object(
+                'beacon_id',
+                NEW.id,
+                'beacon_type',
+                NEW.beacon_type::text,
+                'hub_id',
+                hub.id
+            )
+        );
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_map_beacons_broadcast_near_hub ON public.map_beacons;
+
+CREATE TRIGGER trg_map_beacons_broadcast_near_hub
+    AFTER INSERT ON public.map_beacons
+    FOR EACH ROW
+    EXECUTE FUNCTION public.map_beacons_broadcast_near_hub ();
+
+-- ---------------------------------------------------------------------------
+-- 5. RPC: beacons within radius (meters) of a point — used by Edge + optional server
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.fetch_map_beacons_within (
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION,
+    radius_meters DOUBLE PRECISION DEFAULT 5000
+)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'id',
+                    b.id,
+                    'creator_id',
+                    b.creator_id,
+                    'venue_id',
+                    b.venue_id,
+                    'beacon_type',
+                    b.beacon_type,
+                    'lng',
+                    ST_X (b.location::geometry),
+                    'lat',
+                    ST_Y (b.location::geometry),
+                    'metadata',
+                    b.metadata,
+                    'created_at',
+                    b.created_at,
+                    'expires_at',
+                    b.expires_at
+                )
+                ORDER BY
+                    b.created_at DESC
+            ),
+            '[]'::jsonb
+        )
+    FROM public.map_beacons b
+    WHERE
+        b.expires_at > now()
+        AND ST_DWithin (
+            b.location,
+            ST_SetSRID (ST_MakePoint (lng, lat), 4326)::geography,
+            radius_meters
+        );
+$$;
+
+REVOKE ALL ON FUNCTION public.fetch_map_beacons_within (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.fetch_map_beacons_within (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION) TO authenticated;
+
+COMMENT ON FUNCTION public.fetch_map_beacons_within (DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION) IS
+    'Active map_beacons within radius_m of (lat,lng); SECURITY DEFINER proximity read for authenticated map clients.';
+
+-- ---------------------------------------------------------------------------
+-- 8. Venue manager list (typed JSON — avoids broad table SELECT for map UI)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.insights_venue_map_beacons_list (venue_id_param UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    PERFORM public._assert_venue_manager_for_metrics (venue_id_param);
+
+    RETURN COALESCE(
+        (
+            SELECT
+                jsonb_agg(
+                    jsonb_build_object(
+                        'id',
+                        b.id,
+                        'creator_id',
+                        b.creator_id,
+                        'venue_id',
+                        b.venue_id,
+                        'beacon_type',
+                        b.beacon_type,
+                        'lng',
+                        ST_X (b.location::geometry),
+                        'lat',
+                        ST_Y (b.location::geometry),
+                        'metadata',
+                        b.metadata,
+                        'created_at',
+                        b.created_at,
+                        'expires_at',
+                        b.expires_at
+                    )
+                    ORDER BY
+                        b.created_at DESC
+                )
+            FROM public.map_beacons b
+            WHERE
+                b.venue_id = venue_id_param
+                AND b.expires_at > now ()
+        ),
+        '[]'::jsonb
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.insights_venue_map_beacons_list (UUID) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.insights_venue_map_beacons_list (UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.insights_venue_map_beacons_list (UUID) IS
+    'Active map_beacons for a venue; venue managers only.';
+
+-- ---------------------------------------------------------------------------
+-- 6. Verified venue flag (ops / migration seed for official broadcasting)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.venues
+    ADD COLUMN IF NOT EXISTS is_verified BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.venues.is_verified IS
+    'When true, venue managers may post official soundtrack beacons at venue coordinates.';
+
+-- ---------------------------------------------------------------------------
+-- 7. Manager RPC: beacon density by type within Vibe Radar cell radius (~0.1 mi)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.insights_vibe_radar_beacon_density (venue_id_param UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_lat DOUBLE PRECISION;
+
+    v_lng DOUBLE PRECISION;
+
+    radius_m CONSTANT DOUBLE PRECISION := 160.934;
+
+    rows JSONB;
+BEGIN
+    PERFORM public._assert_venue_manager_for_metrics (venue_id_param);
+
+    SELECT v.latitude, v.longitude
+    INTO v_lat, v_lng
+    FROM public.venues v
+    WHERE v.id = venue_id_param;
+
+    IF v_lat IS NULL OR v_lng IS NULL THEN
+        RETURN jsonb_build_object(
+            'trending',
+            '[]'::jsonb,
+            'venueCenter',
+            jsonb_build_object('lat', NULL, 'lng', NULL),
+            'radiusMeters',
+            radius_m,
+            'status',
+            'venue_coordinates_required'
+        );
+    END IF;
+
+    WITH typed AS (
+        SELECT
+            b.beacon_type::text AS beacon_type,
+            COUNT(*)::bigint AS cnt
+        FROM public.map_beacons b
+        WHERE
+            b.expires_at > now()
+            AND ST_DWithin (
+                b.location,
+                ST_SetSRID (ST_MakePoint (v_lng, v_lat), 4326)::geography,
+                radius_m
+            )
+        GROUP BY
+            b.beacon_type
+    )
+    SELECT
+        COALESCE(
+            (
+                SELECT
+                    jsonb_agg(
+                        jsonb_build_object(
+                            'beacon_type',
+                            t.beacon_type,
+                            'count',
+                            t.cnt
+                        )
+                        ORDER BY
+                            t.cnt DESC
+                    )
+                FROM typed t
+            ),
+            '[]'::jsonb
+        )
+    INTO rows;
+
+    RETURN jsonb_build_object(
+        'trending',
+        rows,
+        'venueCenter',
+        jsonb_build_object('lat', v_lat, 'lng', v_lng),
+        'radiusMeters',
+        radius_m,
+        'status',
+        'ok'
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.insights_vibe_radar_beacon_density (UUID) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.insights_vibe_radar_beacon_density (UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.insights_vibe_radar_beacon_density (UUID) IS
+    'Counts active map_beacons by type within ~0.1 mi of venue; managers only.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds **community and venue map beacons** backed by Postgres/PostGIS, wires **secure Next.js routes** for the dashboard and business insights, and refreshes **MapLibre** maps with **layer toggles** and **native GeoJSON clustering** so dense pins stay readable.

## Database and Edge

- New migration `supabase/migrations/20260501000000_map_beacons.sql`: `map_beacons` table (enum `beacon_type`, geography point, JSON metadata, expiry with 7-day default for soundtracks), scoped RLS (creator + venue managers), `fetch_map_beacons_within` (ST_DWithin, SECURITY DEFINER for proximity reads), `insights_vibe_radar_beacon_density` and `insights_venue_map_beacons_list` RPCs, optional `venues.is_verified` for official broadcasts.
- Trigger posts a hub chat line when **recreation** or **hobby** beacons land inside an active **hub_venues** geofence.
- New Edge Function `supabase/functions/fetch-local-beacons` calling the proximity RPC with the user JWT.

## API and insights

- `GET /api/map/beacons` — authenticated proximity beacon list for the personal map.
- `GET`/`POST /api/insights/[venueId]/beacons` — managers list venue beacons; verified venues can publish an official Spotify playlist pin at venue coordinates (`metadata.is_official`).
- `GET /api/insights/intents` — merges `trendingVibes` from beacon density RPC for the Vibe Radar sidebar.

## UI

- **ConnectionMap**: GeoJSON sources for connections and three beacon groups; glass **Map layers** panel (defaults: My Network + Official Soundtracks on).
- **VibeRadarMap**: Clustered intent layer plus the same beacon stacks and layer panel; label **Availability intents** for the intent layer.
- **VibeRadarClient**: three-column layout with **Trending vibes around you**; fetches venue beacon list for the map.
- **VenueBroadcastingModule** on **Vibe Radar** when `?venue_id=` is set (via **BusinessInsightsShell**).

## Verification

- `npm run lint` (tsc --noEmit)
- `npm test` (87 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-099dc042-aa4c-4af7-af50-ef05c43de27d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-099dc042-aa4c-4af7-af50-ef05c43de27d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lightningbolts/click-web/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added venue broadcasting feature to publish Spotify playlists as venue beacons
  * Introduced map beacon system with support for official, community, and hazard beacon types
  * Added "Trending vibes" dashboard panel showing beacon density analytics
  * Added map layers control panel for toggling beacon visibility
  * Enabled proximity-based beacon discovery on the map

* **Improvements**
  * Enhanced map visualization with clustered markers and improved interactions
  * Updated dashboard layout for better content organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->