### PR TITLE
Thin-client APIs: encounters, ephemeral hubs, public profile, widget vibe, App Links

### DIFF
--- a/__tests__/app/api/connections/encounter.route.contract.test.ts
+++ b/__tests__/app/api/connections/encounter.route.contract.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { POST as encounterPost } from '@/app/api/connections/encounter/route';
+
+const mockGetSupabaseFromRouteRequest = jest.fn();
+
+jest.mock('@/lib/server/supabaseRouteAuth', () => ({
+  getSupabaseFromRouteRequest: (...args: unknown[]) => mockGetSupabaseFromRouteRequest(...args),
+}));
+
+describe('POST /api/connections/encounter contract', () => {
+  const userA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const userB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  beforeEach(() => {
+    mockGetSupabaseFromRouteRequest.mockReset();
+  });
+
+  it('inserts into connection_encounters without touching connections (mocked DB)', async () => {
+    const connectionSelect = jest.fn().mockReturnValue({
+      contains: jest.fn().mockResolvedValue({
+        data: [{ id: 'conn-pair', user_ids: [userA, userB] }],
+        error: null,
+      }),
+    });
+
+    const encounterInsert = jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        maybeSingle: jest.fn().mockResolvedValue({
+          data: { id: 'enc-row-1' },
+          error: null,
+        }),
+      }),
+    });
+
+    const from = jest.fn((table: string) => {
+      if (table === 'connections') {
+        return { select: connectionSelect };
+      }
+      if (table === 'connection_encounters') {
+        return { insert: encounterInsert };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    mockGetSupabaseFromRouteRequest.mockResolvedValue({
+      supabase: { from },
+      user: { id: userA },
+      authError: null,
+    });
+
+    const req = new NextRequest('http://localhost/api/connections/encounter', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer fake.jwt.token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        user_id: userA,
+        peer_id: userB,
+        sensor_data: { lux_level: 42, custom_probe: { x: 1 } },
+      }),
+    });
+
+    const res = await encounterPost(req);
+    expect(res.status).toBe(200);
+
+    expect(from).toHaveBeenCalledWith('connections');
+    expect(from).toHaveBeenCalledWith('connection_encounters');
+    expect(connectionSelect).toHaveBeenCalledWith('id, user_ids');
+    expect(encounterInsert).toHaveBeenCalledTimes(1);
+
+    const insertedArg = encounterInsert.mock.calls[0][0] as Record<string, unknown>;
+    expect(insertedArg.connection_id).toBe('conn-pair');
+    expect(insertedArg.lux_level).toBe(42);
+    expect(insertedArg.vibe_capture).toEqual({ custom_probe: { x: 1 } });
+
+    const json = (await res.json()) as { success: boolean; encounter_id: string | null };
+    expect(json.success).toBe(true);
+    expect(json.encounter_id).toBe('enc-row-1');
+  });
+
+  it('does not surface unique-constraint style failures as 409 when insert succeeds', async () => {
+    const from = jest.fn((table: string) => {
+      if (table === 'connections') {
+        return {
+          select: jest.fn().mockReturnValue({
+            contains: jest.fn().mockResolvedValue({
+              data: [{ id: 'conn-stable', user_ids: [userA, userB] }],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (table === 'connection_encounters') {
+        return {
+          insert: jest.fn().mockReturnValue({
+            select: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: 'second-encounter' },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    mockGetSupabaseFromRouteRequest.mockResolvedValue({
+      supabase: { from },
+      user: { id: userA },
+      authError: null,
+    });
+
+    const req = new NextRequest('http://localhost/api/connections/encounter', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer fake.jwt.token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        user_id: userA,
+        peer_id: userB,
+        sensor_data: {},
+      }),
+    });
+
+    const res = await encounterPost(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { success: boolean };
+    expect(json.success).toBe(true);
+  });
+});

--- a/__tests__/lib/hub/ephemeralHubTtl.test.ts
+++ b/__tests__/lib/hub/ephemeralHubTtl.test.ts
@@ -1,0 +1,11 @@
+import { computeEphemeralHubExpiry } from '@/lib/hub/ephemeralHubTtl';
+
+describe('ephemeral hub TTL (server)', () => {
+  it('computes expires_at exactly 24 hours after the reference instant', () => {
+    const t0 = 1_700_000_000_000;
+    const { expires_at_ms, ttl_ms, expires_at_iso } = computeEphemeralHubExpiry(t0);
+    expect(ttl_ms).toBe(24 * 60 * 60 * 1000);
+    expect(expires_at_ms).toBe(t0 + ttl_ms);
+    expect(Date.parse(expires_at_iso)).toBe(expires_at_ms);
+  });
+});

--- a/app/api/connections/encounter/route.ts
+++ b/app/api/connections/encounter/route.ts
@@ -12,6 +12,16 @@ function isUuidLike(v: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
 }
 
+function isEncounterRateLimitError(err: { message?: string; details?: string; hint?: string } | null): boolean {
+  if (!err) return false;
+  const combined = [
+    err.message ?? '',
+    err.details ?? '',
+    err.hint ?? '',
+  ].join(' ');
+  return combined.includes('encounter_rate_limit_3h');
+}
+
 type ConnectionRow = { id: string; user_ids?: string[] | null };
 
 function pickPairwiseConnection(rows: ConnectionRow[] | null, selfId: string, peerId: string): string | null {
@@ -89,7 +99,7 @@ export async function POST(request: NextRequest) {
 
     if (insErr) {
       const msg = insErr.message ?? '';
-      if (msg.includes('encounter_rate_limit_3h')) {
+      if (isEncounterRateLimitError(insErr)) {
         return NextResponse.json(
           {
             success: false,
@@ -101,7 +111,7 @@ export async function POST(request: NextRequest) {
         );
       }
       console.error('connections/encounter insert:', msg);
-      return NextResponse.json({ error: 'Failed to record encounter', detail: msg }, { status: 500 });
+      return NextResponse.json({ error: 'Failed to record encounter' }, { status: 500 });
     }
 
     return NextResponse.json({
@@ -112,6 +122,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : 'Unexpected error';
-    return NextResponse.json({ error: msg }, { status: 500 });
+    console.error('connections/encounter error:', msg);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/connections/encounter/route.ts
+++ b/app/api/connections/encounter/route.ts
@@ -1,0 +1,117 @@
+/**
+ * POST /api/connections/encounter
+ * Lightweight encounter log: inserts `connection_encounters` only (no `connections` writes).
+ * Body: { user_id, peer_id, sensor_data? }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseFromRouteRequest } from '@/lib/server/supabaseRouteAuth';
+import { buildEncounterInsertFromSensor } from '@/lib/connections/encounterSensorPayload';
+
+function isUuidLike(v: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
+}
+
+type ConnectionRow = { id: string; user_ids?: string[] | null };
+
+function pickPairwiseConnection(rows: ConnectionRow[] | null, selfId: string, peerId: string): string | null {
+  if (!rows?.length) return null;
+  const pair = new Set([selfId, peerId]);
+  for (const row of rows) {
+    const ids = row.user_ids ?? [];
+    if (ids.length !== 2) continue;
+    const a = String(ids[0] ?? '').trim();
+    const b = String(ids[1] ?? '').trim();
+    if (!pair.has(a) || !pair.has(b)) continue;
+    return String(row.id);
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { supabase, user, authError } = await getSupabaseFromRouteRequest(request);
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: 'Body must be a JSON object' }, { status: 400 });
+    }
+
+    const raw = body as Record<string, unknown>;
+    const userId = typeof raw.user_id === 'string' ? raw.user_id.trim() : '';
+    const peerId = typeof raw.peer_id === 'string' ? raw.peer_id.trim() : '';
+    const sensorData = raw.sensor_data;
+
+    if (!userId || !peerId) {
+      return NextResponse.json({ error: 'user_id and peer_id are required' }, { status: 400 });
+    }
+    if (!isUuidLike(userId) || !isUuidLike(peerId)) {
+      return NextResponse.json({ error: 'user_id and peer_id must be UUIDs' }, { status: 400 });
+    }
+    if (userId !== user.id) {
+      return NextResponse.json({ error: 'user_id must match the authenticated user' }, { status: 403 });
+    }
+    if (peerId === userId) {
+      return NextResponse.json({ error: 'peer_id must differ from user_id' }, { status: 400 });
+    }
+
+    const { data: connRows, error: connErr } = await supabase
+      .from('connections')
+      .select('id, user_ids')
+      .contains('user_ids', [userId, peerId]);
+
+    if (connErr) {
+      console.error('connections/encounter connection lookup:', connErr.message);
+      return NextResponse.json({ error: 'Failed to resolve connection' }, { status: 500 });
+    }
+
+    const connectionId = pickPairwiseConnection((connRows ?? []) as ConnectionRow[], userId, peerId);
+    if (!connectionId) {
+      return NextResponse.json({ error: 'No pairwise connection found for this pair' }, { status: 404 });
+    }
+
+    const insertRow = buildEncounterInsertFromSensor(connectionId, sensorData);
+
+    const { data: inserted, error: insErr } = await supabase
+      .from('connection_encounters')
+      .insert(insertRow)
+      .select('id')
+      .maybeSingle();
+
+    if (insErr) {
+      const msg = insErr.message ?? '';
+      if (msg.includes('encounter_rate_limit_3h')) {
+        return NextResponse.json(
+          {
+            success: false,
+            encounter_id: null,
+            rate_limited: true,
+            message: 'Encounter rate limit active (3h server window).',
+          },
+          { status: 429 },
+        );
+      }
+      console.error('connections/encounter insert:', msg);
+      return NextResponse.json({ error: 'Failed to record encounter', detail: msg }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      encounter_id: inserted?.id != null ? String(inserted.id) : null,
+      connection_id: connectionId,
+      rate_limited: false,
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Unexpected error';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/app/api/connections/route.ts
+++ b/app/api/connections/route.ts
@@ -63,6 +63,16 @@ function firstNonEmptyString(values: unknown[]): string | null {
   return null;
 }
 
+function isEncounterRateLimitError(err: { message?: string; details?: string; hint?: string } | null): boolean {
+  if (!err) return false;
+  const combined = [
+    err.message ?? '',
+    err.details ?? '',
+    err.hint ?? '',
+  ].join(' ');
+  return combined.includes('encounter_rate_limit_3h');
+}
+
 function extractDisplayLocation(semanticLocation: Record<string, unknown>): string {
   const address = isRecord(semanticLocation.address) ? semanticLocation.address : null;
   if (!address) return DISPLAY_LOCATION_FALLBACK;
@@ -1153,8 +1163,7 @@ export async function POST(request: NextRequest) {
     let encounter_logged = true;
     let encounter_reason: string | undefined;
     if (encounterErr) {
-      const msg = encounterErr.message ?? '';
-      if (msg.includes('encounter_rate_limit_3h')) {
+      if (isEncounterRateLimitError(encounterErr)) {
         encounter_logged = false;
         encounter_reason = 'rate_limit_active';
         await adminClient.from('chats').update({ updated_at: now }).eq('connection_id', connection.id);

--- a/app/api/hub/create/route.ts
+++ b/app/api/hub/create/route.ts
@@ -1,0 +1,102 @@
+/**
+ * POST /api/hub/create
+ * Ephemeral community hub: server computes expires_at (now + 24h), inserts hub + creator participant.
+ */
+
+import { randomUUID } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { computeEphemeralHubExpiry } from '@/lib/hub/ephemeralHubTtl';
+import { createChatGatekeeperAdmin, requireBearerUser } from '@/lib/server/chatGatekeeper';
+
+type LocationPayload = {
+  latitude?: number;
+  longitude?: number;
+  lat?: number;
+  lng?: number;
+  radius_meters?: number;
+};
+
+function parseLocation(raw: unknown): { lat: number; lng: number; radius: number } | null {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const o = raw as LocationPayload;
+  const lat = typeof o.latitude === 'number' ? o.latitude : typeof o.lat === 'number' ? o.lat : null;
+  const lng = typeof o.longitude === 'number' ? o.longitude : typeof o.lng === 'number' ? o.lng : null;
+  if (lat == null || lng == null || Number.isNaN(lat) || Number.isNaN(lng)) return null;
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+  const radius =
+    typeof o.radius_meters === 'number' && Number.isFinite(o.radius_meters) && o.radius_meters > 0
+      ? Math.min(Math.floor(o.radius_meters), 5_000)
+      : 50;
+  return { lat, lng, radius };
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireBearerUser(request);
+  if (!auth.ok) return auth.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const category = typeof body.category === 'string' ? body.category.trim() : 'general';
+  const location = parseLocation(body.location);
+
+  if (!name) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+  if (!category) {
+    return NextResponse.json({ error: 'category is required' }, { status: 400 });
+  }
+  if (!location) {
+    return NextResponse.json(
+      { error: 'location must include latitude/longitude (or lat/lng) within valid ranges' },
+      { status: 400 },
+    );
+  }
+
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey?.trim()) {
+    return NextResponse.json({ error: 'Hub creation requires server configuration' }, { status: 503 });
+  }
+
+  const hubId = `hub_${randomUUID().replace(/-/g, '')}`;
+  const { expires_at_iso } = computeEphemeralHubExpiry();
+
+  const admin = createChatGatekeeperAdmin();
+
+  const hubRow = {
+    id: hubId,
+    name,
+    category,
+    geofence_lat: location.lat,
+    geofence_long: location.lng,
+    radius_meters: location.radius,
+    expires_at: expires_at_iso,
+    creator_id: auth.user.id,
+  };
+
+  const { error: hubErr } = await admin.from('hub_venues').insert(hubRow);
+  if (hubErr) {
+    console.error('hub/create hub_venues:', hubErr.message);
+    return NextResponse.json({ error: 'Failed to create hub', detail: hubErr.message }, { status: 500 });
+  }
+
+  const { error: partErr } = await admin.from('hub_participants').insert({
+    hub_id: hubId,
+    user_id: auth.user.id,
+  });
+  if (partErr) {
+    console.error('hub/create hub_participants:', partErr.message);
+    await admin.from('hub_venues').delete().eq('id', hubId);
+    return NextResponse.json({ error: 'Failed to register hub participant', detail: partErr.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    hub_id: hubId,
+    expires_at: expires_at_iso,
+  });
+}

--- a/app/api/hub/create/route.ts
+++ b/app/api/hub/create/route.ts
@@ -79,20 +79,14 @@ export async function POST(request: NextRequest) {
     creator_id: auth.user.id,
   };
 
-  const { error: hubErr } = await admin.from('hub_venues').insert(hubRow);
-  if (hubErr) {
-    console.error('hub/create hub_venues:', hubErr.message);
-    return NextResponse.json({ error: 'Failed to create hub', detail: hubErr.message }, { status: 500 });
-  }
-
-  const { error: partErr } = await admin.from('hub_participants').insert({
-    hub_id: hubId,
+  const { error: rpcErr } = await admin.rpc('create_hub_with_participant', {
+    hub_row: hubRow,
     user_id: auth.user.id,
   });
-  if (partErr) {
-    console.error('hub/create hub_participants:', partErr.message);
-    await admin.from('hub_venues').delete().eq('id', hubId);
-    return NextResponse.json({ error: 'Failed to register hub participant', detail: partErr.message }, { status: 500 });
+
+  if (rpcErr) {
+    console.error('hub/create RPC error:', rpcErr.message);
+    return NextResponse.json({ error: 'Failed to create hub' }, { status: 500 });
   }
 
   return NextResponse.json({

--- a/app/api/insights/widget-vibe/route.ts
+++ b/app/api/insights/widget-vibe/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /api/insights/widget-vibe
+ * Home-screen widget payload (pre-formatted strings + counts). Cached at the edge for five minutes.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseFromRouteRequest } from '@/lib/server/supabaseRouteAuth';
+import { buildWidgetVibePayload } from '@/lib/insights/widgetVibePayload';
+
+export const revalidate = 300;
+
+const CACHE_HEADER = 'private, s-maxage=300, stale-while-revalidate';
+
+export async function GET(request: NextRequest) {
+  const { supabase, user, authError } = await getSupabaseFromRouteRequest(request);
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from('connections')
+    .select('id, status, expiry_state, has_begun, user_ids')
+    .contains('user_ids', [user.id]);
+
+  if (error) {
+    console.error('widget-vibe connections:', error.message);
+    return NextResponse.json({ error: 'Failed to load connections' }, { status: 500 });
+  }
+
+  const payload = buildWidgetVibePayload((data ?? []) as Record<string, unknown>[]);
+  return NextResponse.json(payload, {
+    headers: {
+      'Cache-Control': CACHE_HEADER,
+      Vary: 'Authorization',
+    },
+  });
+}

--- a/app/api/insights/widget-vibe/route.ts
+++ b/app/api/insights/widget-vibe/route.ts
@@ -9,7 +9,7 @@ import { buildWidgetVibePayload } from '@/lib/insights/widgetVibePayload';
 
 export const revalidate = 300;
 
-const CACHE_HEADER = 'private, s-maxage=300, stale-while-revalidate';
+const CACHE_HEADER = 'public, s-maxage=300, stale-while-revalidate=300';
 
 export async function GET(request: NextRequest) {
   const { supabase, user, authError } = await getSupabaseFromRouteRequest(request);

--- a/app/api/users/[userId]/public-profile/route.ts
+++ b/app/api/users/[userId]/public-profile/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET /api/users/[userId]/public-profile
+ * Unauthenticated App Clip / deep-link preview: only non-sensitive display fields.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+
+function isUuidLike(v: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
+}
+
+type PublicProfileRow = {
+  name?: string | null;
+  full_name?: string | null;
+  image?: string | null;
+  aura_colors?: string[] | null;
+};
+
+function displayName(row: PublicProfileRow): string {
+  const n = typeof row.name === 'string' ? row.name.trim() : '';
+  if (n) return n;
+  const f = typeof row.full_name === 'string' ? row.full_name.trim() : '';
+  if (f) return f;
+  return 'Click member';
+}
+
+function createServiceReader() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function GET(
+  _req: NextRequest,
+  context: { params: Promise<{ userId: string }> },
+) {
+  const { userId } = await context.params;
+  const id = userId?.trim() ?? '';
+  if (!id || !isUuidLike(id)) {
+    return NextResponse.json({ error: 'Invalid user id' }, { status: 400 });
+  }
+
+  const admin = createServiceReader();
+  if (!admin) {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 });
+  }
+
+  const { data, error } = await admin
+    .from('users')
+    .select('name, full_name, image, aura_colors')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    console.error('public-profile:', error.message);
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  if (!data) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const row = data as PublicProfileRow;
+  const aura = Array.isArray(row.aura_colors)
+    ? row.aura_colors.filter((c): c is string => typeof c === 'string' && c.trim().length > 0)
+    : [];
+
+  const body = {
+    display_name: displayName(row),
+    avatar_url: typeof row.image === 'string' && row.image.trim() ? row.image.trim() : null,
+    aura_colors: aura.length > 0 ? aura : ['#6366f1', '#a855f7', '#ec4899'],
+  };
+
+  return NextResponse.json(body, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+    },
+  });
+}

--- a/app/api/users/[userId]/public-profile/route.ts
+++ b/app/api/users/[userId]/public-profile/route.ts
@@ -3,8 +3,8 @@
  * Unauthenticated App Clip / deep-link preview: only non-sensitive display fields.
  */
 
-import { createClient } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
+import { createSupabaseServiceRoleClient } from '@/lib/server/supabaseServer';
 
 function isUuidLike(v: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
@@ -25,13 +25,6 @@ function displayName(row: PublicProfileRow): string {
   return 'Click member';
 }
 
-function createServiceReader() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) return null;
-  return createClient(url, key, { auth: { persistSession: false } });
-}
-
 export async function GET(
   _req: NextRequest,
   context: { params: Promise<{ userId: string }> },
@@ -42,10 +35,7 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid user id' }, { status: 400 });
   }
 
-  const admin = createServiceReader();
-  if (!admin) {
-    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 });
-  }
+  const admin = createSupabaseServiceRoleClient();
 
   const { data, error } = await admin
     .from('users')
@@ -55,7 +45,7 @@ export async function GET(
 
   if (error) {
     console.error('public-profile:', error.message);
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
   if (!data) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });

--- a/lib/connections/encounterSensorPayload.ts
+++ b/lib/connections/encounterSensorPayload.ts
@@ -1,0 +1,60 @@
+/**
+ * Maps client `sensor_data` into `connection_encounters` insert columns.
+ * Unknown keys are folded into `vibe_capture` so the parent `connections` row stays untouched.
+ */
+
+const ENCOUNTER_COLUMN_KEYS = new Set<string>([
+  'lux_level',
+  'motion_variance',
+  'compass_azimuth',
+  'battery_level',
+  'exact_noise_level_db',
+  'exact_barometric_elevation_m',
+  'relative_altitude_m',
+  'gps_lat',
+  'gps_lon',
+  'weather_snapshot',
+  'noise_level',
+  'semantic_location',
+  'display_location',
+  'location_name',
+  'context_tags',
+  'elevation_category',
+]);
+
+export type EncounterSensorInsert = Record<string, unknown>;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+export function buildEncounterInsertFromSensor(
+  connectionId: string,
+  sensorData: unknown,
+): EncounterSensorInsert {
+  const row: EncounterSensorInsert = {
+    connection_id: connectionId,
+    encountered_at: new Date().toISOString(),
+    context_tags: [] as string[],
+  };
+
+  const extras: Record<string, unknown> = {};
+
+  if (!isPlainObject(sensorData)) {
+    return row;
+  }
+
+  for (const [key, value] of Object.entries(sensorData)) {
+    if (ENCOUNTER_COLUMN_KEYS.has(key)) {
+      row[key] = value;
+      continue;
+    }
+    extras[key] = value;
+  }
+
+  if (Object.keys(extras).length > 0) {
+    row.vibe_capture = extras;
+  }
+
+  return row;
+}

--- a/lib/hub/ephemeralHubTtl.ts
+++ b/lib/hub/ephemeralHubTtl.ts
@@ -1,0 +1,21 @@
+const TWENTY_FOUR_H_MS = 24 * 60 * 60 * 1000;
+
+export type HubExpiryComputation = {
+  /** ISO-8601 UTC timestamp when the hub stops accepting traffic. */
+  expires_at_iso: string;
+  /** Same instant as epoch milliseconds (server clock). */
+  expires_at_ms: number;
+  ttl_ms: number;
+};
+
+/**
+ * Server-side TTL for ephemeral hubs (thin client must not compute this).
+ */
+export function computeEphemeralHubExpiry(nowMs: number = Date.now()): HubExpiryComputation {
+  const expiresAtMs = nowMs + TWENTY_FOUR_H_MS;
+  return {
+    expires_at_iso: new Date(expiresAtMs).toISOString(),
+    expires_at_ms: expiresAtMs,
+    ttl_ms: TWENTY_FOUR_H_MS,
+  };
+}

--- a/lib/insights/widgetVibePayload.ts
+++ b/lib/insights/widgetVibePayload.ts
@@ -1,0 +1,42 @@
+import { isActiveChatListStatus, normalizeConnectionStatus } from '@/lib/dashboard/connectionStatus';
+
+export type WidgetVibePayload = {
+  status_text: string;
+  density_hex_color: string;
+  active_counts: number;
+};
+
+type ConnectionCountRow = Record<string, unknown>;
+
+function densityColorForCount(n: number): string {
+  if (n <= 0) return '#94a3b8';
+  if (n <= 3) return '#22c55e';
+  if (n <= 8) return '#eab308';
+  if (n <= 15) return '#f97316';
+  return '#a855f7';
+}
+
+function statusTextForCount(n: number): string {
+  if (n <= 0) return 'Quiet — open Click when you are ready to vibe.';
+  if (n === 1) return 'One active thread — your circle is humming.';
+  return `${n} active connections — energy is building on Click.`;
+}
+
+export function countActiveConnections(rows: ConnectionCountRow[] | null | undefined): number {
+  if (!rows?.length) return 0;
+  let n = 0;
+  for (const row of rows) {
+    const st = normalizeConnectionStatus(row);
+    if (isActiveChatListStatus(st)) n += 1;
+  }
+  return n;
+}
+
+export function buildWidgetVibePayload(rows: ConnectionCountRow[] | null | undefined): WidgetVibePayload {
+  const active_counts = countActiveConnections(rows);
+  return {
+    status_text: statusTextForCount(active_counts),
+    density_hex_color: densityColorForCount(active_counts),
+    active_counts,
+  };
+}

--- a/lib/server/hubGatekeeper.ts
+++ b/lib/server/hubGatekeeper.ts
@@ -40,7 +40,7 @@ export async function assertHubGeofenceFromCoords(
 
   const { data: venue, error } = await admin
     .from('hub_venues')
-    .select('id, geofence_lat, geofence_long, radius_meters')
+    .select('id, geofence_lat, geofence_long, radius_meters, expires_at')
     .eq('id', trimmed)
     .maybeSingle();
 
@@ -50,6 +50,14 @@ export async function assertHubGeofenceFromCoords(
   }
   if (!venue) {
     return NextResponse.json({ error: 'Unknown hub' }, { status: 404 });
+  }
+
+  const expiresRaw = venue.expires_at as string | null | undefined;
+  if (expiresRaw) {
+    const expMs = Date.parse(expiresRaw);
+    if (Number.isFinite(expMs) && expMs <= Date.now()) {
+      return NextResponse.json({ error: 'Hub expired' }, { status: 410 });
+    }
   }
 
   const radius =

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",
+    "verify:well-known": "node scripts/verify-well-known-json.mjs",
     "icons": "node scripts/generate-brand-icons.mjs"
   },
   "dependencies": {

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,14 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID.com.click.app",
+        "paths": ["/api/users/*/public-profile", "/u/*", "/users/*"]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": ["TEAMID.com.click.app"]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.click.app",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_RELEASE_SHA256_HEX_COLON_SEPARATED"
+      ]
+    }
+  }
+]

--- a/scripts/verify-well-known-json.mjs
+++ b/scripts/verify-well-known-json.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * Validates JSON syntax for Universal Links / App Links static files.
+ * Usage: node scripts/verify-well-known-json.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const files = [
+  join(root, 'public', '.well-known', 'apple-app-site-association'),
+  join(root, 'public', '.well-known', 'assetlinks.json'),
+];
+
+let failed = false;
+for (const f of files) {
+  const raw = readFileSync(f, 'utf8');
+  try {
+    JSON.parse(raw);
+    console.log(`OK  ${f}`);
+  } catch (e) {
+    failed = true;
+    console.error(`BAD ${f}:`, e instanceof Error ? e.message : e);
+  }
+}
+
+if (failed) process.exit(1);

--- a/scripts/verify-well-known-json.mjs
+++ b/scripts/verify-well-known-json.mjs
@@ -16,12 +16,27 @@ const files = [
   join(root, 'public', '.well-known', 'assetlinks.json'),
 ];
 
+const PLACEHOLDER_PATTERNS = ['<%=', '{{', '__REPLACE__', 'REPLACE_ME'];
+
 let failed = false;
 for (const f of files) {
   const raw = readFileSync(f, 'utf8');
   try {
     JSON.parse(raw);
-    console.log(`OK  ${f}`);
+
+    // Check for placeholder tokens
+    let foundPlaceholder = false;
+    for (const pattern of PLACEHOLDER_PATTERNS) {
+      if (raw.includes(pattern)) {
+        failed = true;
+        foundPlaceholder = true;
+        console.error(`BAD ${f}: Contains deploy-time placeholder token "${pattern}"`);
+      }
+    }
+
+    if (!foundPlaceholder) {
+      console.log(`OK  ${f}`);
+    }
   } catch (e) {
     failed = true;
     console.error(`BAD ${f}:`, e instanceof Error ? e.message : e);

--- a/supabase/functions/bind-proximity-connection/index.ts
+++ b/supabase/functions/bind-proximity-connection/index.ts
@@ -235,6 +235,16 @@ function isDuplicateKeyError(err: { message?: string; code?: string } | null): b
   return code === '23505' || msg.includes('duplicate key') || msg.includes('unique constraint');
 }
 
+function isEncounterRateLimitError(err: { message?: string; details?: string; hint?: string } | null): boolean {
+  if (!err) return false;
+  const combined = [
+    err.message ?? '',
+    err.details ?? '',
+    err.hint ?? '',
+  ].join(' ');
+  return combined.includes('encounter_rate_limit_3h');
+}
+
 /** Client `context_tags`: trimmed non-empty strings, order preserved, deduped. */
 function normalizeContextTagsArray(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
@@ -831,8 +841,7 @@ Deno.serve(async (req) => {
     if (encLat == null || encLon == null || newBlock == null) {
       const { error: encErr } = await admin.from('connection_encounters').insert(insertRow);
       if (encErr) {
-        const msg = encErr.message ?? '';
-        if (msg.includes('encounter_rate_limit_3h')) {
+        if (isEncounterRateLimitError(encErr)) {
           const nowMs = Date.now();
           await admin.from('chats').update({ updated_at: nowMs }).eq('connection_id', connectionId);
           return 'rate_limited';
@@ -892,8 +901,7 @@ Deno.serve(async (req) => {
 
     const { error: encErr } = await admin.from('connection_encounters').insert(insertRow);
     if (encErr) {
-      const msg = encErr.message ?? '';
-      if (msg.includes('encounter_rate_limit_3h')) {
+      if (isEncounterRateLimitError(encErr)) {
         const nowMs = Date.now();
         await admin.from('chats').update({ updated_at: nowMs }).eq('connection_id', connectionId);
         return 'rate_limited';

--- a/supabase/functions/bind-proximity-connection/index.ts
+++ b/supabase/functions/bind-proximity-connection/index.ts
@@ -913,6 +913,8 @@ Deno.serve(async (req) => {
     reason?: string;
   };
   const peerEncounterLogged: PeerBindMeta[] = [];
+  /** True only when this bind created a new row in `connections` (strict server boolean for clients). */
+  let handshakeCreatedNewConnection = false;
   const ensured = await ensureConnectionForMemberSet(memberIds);
   if (!ensured) {
     ids.forEach((peerId) => {
@@ -920,13 +922,14 @@ Deno.serve(async (req) => {
         peerId,
         connectionId: null,
         encounterLogged: false,
-        isNewConnection: true,
+        isNewConnection: false,
         encounterPersistedOnBind: false,
         reason: 'connection_unavailable',
       });
     });
   } else {
     const { connectionId, isNewConnection } = ensured;
+    handshakeCreatedNewConnection = isNewConnection;
     const peerRows = ids
       .map((peerId) => rows.find((r) => r && String(r.user_id) === peerId) as Record<string, unknown> | undefined)
       .filter((r): r is Record<string, unknown> => r != null);
@@ -1031,7 +1034,7 @@ Deno.serve(async (req) => {
             : 0,
       connection_id: meta?.connectionId ?? null,
       encounter_logged,
-      is_new_connection: meta?.isNewConnection ?? true,
+      is_new_connection: meta != null ? meta.isNewConnection : false,
       encounter_persisted_on_bind: meta?.encounterPersistedOnBind ?? false,
       ...(meta?.reason ? { reason: meta.reason } : {}),
     };
@@ -1046,7 +1049,7 @@ Deno.serve(async (req) => {
   const sharedConnectionId = peerEncounterLogged.find((p) => p.connectionId != null)?.connectionId ?? null;
   if (sharedConnectionId != null) {
     responseBody.connection_id = sharedConnectionId;
-    responseBody.is_new_connection = peerEncounterLogged.some((p) => p.isNewConnection);
+    responseBody.is_new_connection = handshakeCreatedNewConnection;
     responseBody.is_group = memberIds.length > 2;
   }
   if (memberIds.length > 2) {

--- a/supabase/migrations/20260511120000_hub_ephemeral_participants_and_users_aura.sql
+++ b/supabase/migrations/20260511120000_hub_ephemeral_participants_and_users_aura.sql
@@ -1,0 +1,46 @@
+-- Ephemeral hub metadata, participant registry, and public-safe profile colors.
+
+ALTER TABLE public.hub_venues
+    ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT 'general';
+
+ALTER TABLE public.hub_venues
+    ADD COLUMN IF NOT EXISTS expires_at timestamptz;
+
+ALTER TABLE public.hub_venues
+    ADD COLUMN IF NOT EXISTS creator_id uuid REFERENCES auth.users (id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.hub_venues.category IS 'Hub segment label (server-assigned from create payload).';
+
+COMMENT ON COLUMN public.hub_venues.expires_at IS 'When the hub stops accepting geofenced traffic; set at creation (now + 24h).';
+
+UPDATE public.hub_venues
+SET
+    expires_at = created_at + interval '24 hours'
+WHERE
+    expires_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_hub_venues_expires_at ON public.hub_venues (expires_at);
+
+CREATE TABLE IF NOT EXISTS public.hub_participants (
+    hub_id text NOT NULL REFERENCES public.hub_venues (id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+    joined_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (hub_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hub_participants_user_id ON public.hub_participants (user_id);
+
+COMMENT ON TABLE public.hub_participants IS 'Hub membership rows; maintained by trusted API (service role).';
+
+ALTER TABLE public.hub_participants ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.hub_participants FROM anon;
+
+REVOKE ALL ON public.hub_participants FROM authenticated;
+
+GRANT ALL ON public.hub_participants TO service_role;
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS aura_colors text[] DEFAULT ARRAY['#6366f1', '#a855f7', '#ec4899']::text[];
+
+COMMENT ON COLUMN public.users.aura_colors IS 'Public palette for share / App Clip previews (no PII).';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements four backend-facing features with server-side TTLs, booleans, and formatted payloads so clients stay thin.

### Feature 1 — Reconnection bypass & lightweight encounters
- **Edge function** `bind-proximity-connection`: `is_new_connection` at the handshake level now reflects whether this bind **created** a `connections` row (`handshakeCreatedNewConnection`), not `some()` across peers. Unavailable-connection peers use `is_new_connection: false` instead of defaulting to true. Per-match objects default `is_new_connection` to false when metadata is missing.
- **POST** [`/api/connections/encounter`](app/api/connections/encounter/route.ts): Authenticated user (`getSupabaseFromRouteRequest` → `auth.getUser()`), resolves the **pairwise** `connections` row, inserts **only** `connection_encounters` (sensor columns + `vibe_capture` for unknown keys). Returns 429 with a clear body when the DB 3h encounter guard fires.

### Feature 2 — Ephemeral community hub creation
- Migration adds `category`, `expires_at`, `creator_id` on `hub_venues`, new `hub_participants`, and `users.aura_colors`.
- **POST** [`/api/hub/create`](app/api/hub/create/route.ts): Requires `Authorization: Bearer` + service role env; computes `expires_at` via [`computeEphemeralHubExpiry`](lib/hub/ephemeralHubTtl.ts) (now + 24h); inserts hub + creator participant; rolls back hub row if participant insert fails.
- [`hubGatekeeper`](lib/server/hubGatekeeper.ts) returns **410** when `expires_at` is in the past.

### Feature 3 — App Clips / deep links
- **GET** [`/api/users/[userId]/public-profile`](app/api/users/[userId]/public-profile/route.ts): No auth; service role reads only `display_name`, `avatar_url`, and `aura_colors` (defaults when unset). Returns 503 if service role is not configured.
- Static [`public/.well-known/apple-app-site-association`](public/.well-known/apple-app-site-association) and [`assetlinks.json`](public/.well-known/assetlinks.json) with placeholder Team ID / package / SHA256 for production substitution.

### Feature 4 — Widget vibe
- **GET** [`/api/insights/widget-vibe`](app/api/insights/widget-vibe/route.ts): Auth via session or bearer; aggregates active connections with existing lifecycle helpers; returns `{ status_text, density_hex_color, active_counts }` plus `Cache-Control: private, s-maxage=300, stale-while-revalidate` and `Vary: Authorization`. Segment `revalidate = 300`.

### Testing & tooling
- Jest: encounter route contract (mocked Supabase) + 24h TTL unit test.
- `npm run verify:well-known` runs [`scripts/verify-well-known-json.mjs`](scripts/verify-well-known-json.mjs).

## Deploy notes
- Apply new Supabase migration before relying on hub create / `aura_colors` / `expires_at` columns.
- Replace `TEAMID`, `com.click.app`, and the Android SHA256 placeholder in the `.well-known` files for production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0981c4d-5f28-4d06-ac46-54c5a85ffe3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0981c4d-5f28-4d06-ac46-54c5a85ffe3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection encounter recording API, ephemeral hub creation, public user profiles, and a connection-activity “vibe” widget.
  * Ephemeral hubs expire after 24 hours; hubs support categories and participants.
  * Universal deep-linking assets for Apple and Android.

* **Bug Fixes / Reliability**
  * Improved encounter rate-limit detection and expired-hub handling.

* **Tests**
  * Added encounter API contract tests and ephemeral-hub TTL tests.

* **Chores**
  * Validation script and package script for well-known assets; DB migration to support hubs and aura colors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightningbolts/click-web/pull/18)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->